### PR TITLE
Passing custom args to HandleFunc

### DIFF
--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -75,7 +75,7 @@ func NewClient(c diam.Conn) {
 	ip, _, _ := net.SplitHostPort(laddr.String())
 	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, format.Address(net.ParseIP(ip)))
 	m.NewAVP(avp.VendorId, avp.Mbit, 0, VendorId)
-	m.NewAVP(avp.ProductName, avp.Mbit, 0, ProductName)
+	m.NewAVP(avp.ProductName, 0, 0, ProductName)
 	m.NewAVP(avp.OriginStateId, avp.Mbit, 0, format.Unsigned32(rand.Uint32()))
 	m.NewAVP(avp.VendorSpecificApplicationId, avp.Mbit, 0, &diam.GroupedAVP{
 		AVP: []*diam.AVP{


### PR DESCRIPTION
I have the following function which takes a transaction_id and msisdn and tries to create a Credit-ControlRequest:

```go
func Charge(transaction_id string, msisdn string, server_address string) (session_id string, result_code string) {

  dict.Default.Load(bytes.NewReader(dict.CreditControlXML))

  // ALL incoming messages are handled here.
  diam.HandleFunc("CEA", OnCEA) // I want to pass the transaction_id and msisdn through here
  diam.HandleFunc("CCA", OnCCA)
  diam.HandleFunc("ALL", OnMSG) // Catch-all.

  var (
    c   diam.Conn
    err error
  )
  c, err = diam.Dial(server_address, nil, nil)

  if err != nil {
    log.Fatal(err)
  }

  go NewClient(c)

  // Wait until the server kicks us out.

  <-c.(diam.CloseNotifier).CloseNotify()
  log.Println("Server disconnected.")
}

// I want this function to accept the transaction_id and msisdn as well so I can add it to the CCR AVP
func OnCEA(c diam.Conn, m *diam.Message) {
  rc, err := m.FindAVP(avp.ResultCode)
  if err != nil {
    log.Fatal(err)
  }
  if v, _ := rc.Data.(format.Unsigned32); v != diam.Success {
    log.Fatal("Unexpected response:", rc)
  }

  // Craft a CCR message.
  r := diam.NewRequest(diam.CreditControl, 4, nil)

// Add AVP's containing transaction_id and msisdn
}

func OnCCA(c diam.Conn, m *diam.Message) {
  // Here I want to return the result_code and session_id extracted from the AVP's
}
```

I can't set `transaction_id` or `msisdn` to a global variable, since this will cause problems with concurrency. So the only solution I can come up with at the moment is to send both the `CER` and `CCR` in the same function and hardcoding for example `DestinationRealm` instead of using the response in the `CEA`.

I looked through the RFC but I couldn't see anything in the spec for passing variables through - e.g sending `transaction_id` and `msisdn` in the `CER` and having it returned in the `CEA`.

Am I missing something simple here?