### PR TITLE
Missing Origin-State-Id should not make DWR fail since it's optional

### DIFF
--- a/diam/sm/dwr.go
+++ b/diam/sm/dwr.go
@@ -15,8 +15,8 @@ import (
 
 // handleDWR handles Device-Watchdog-Request messages.
 //
-// If mandatory AVPs such as Origin-Host, Origin-Realm, or
-// Origin-State-Id are missing, we ignore the message.
+// If mandatory AVPs such as Origin-Host or Origin-Realm are missing,
+// we ignore the message.
 //
 // See RFC 6733 section 5.5 for details.
 func handleDWR(sm *StateMachine) diam.HandlerFunc {

--- a/diam/sm/smparser/dwr.go
+++ b/diam/sm/smparser/dwr.go
@@ -38,8 +38,5 @@ func (dwr *DWR) sanityCheck() error {
 	if len(dwr.OriginRealm) == 0 {
 		return ErrMissingOriginRealm
 	}
-	if dwr.OriginStateID == nil {
-		return ErrMissingOriginStateID
-	}
 	return nil
 }

--- a/diam/sm/smparser/dwr_test.go
+++ b/diam/sm/smparser/dwr_test.go
@@ -32,17 +32,6 @@ func TestDWR_MissingOriginRealm(t *testing.T) {
 	}
 }
 
-func TestDWR_MissingOriginStateID(t *testing.T) {
-	m := diam.NewRequest(diam.CapabilitiesExchange, 0, dict.Default)
-	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity("foobar"))
-	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity("test"))
-	dwr := new(DWR)
-	err := dwr.Parse(m)
-	if err != nil && err != ErrMissingOriginStateID {
-		t.Fatal("Unexpected error:", err)
-	}
-}
-
 func TestDWR_OK(t *testing.T) {
 	m := diam.NewRequest(diam.CapabilitiesExchange, 0, dict.Default)
 	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity("foobar"))


### PR DESCRIPTION
Ran into this issue when deploying the sample diameter server: The client I was dealing with was not providing an Origin-State-Id in the DWR commands, which seems to be according to spec.

Also as per RFC-3588, 5.5.1 + 8.16 (https://tools.ietf.org/html/rfc3588)