### PR TITLE
Support for searching grouped avps, support for search to return multiple avps

### DIFF
--- a/diam/message.go
+++ b/diam/message.go
@@ -318,7 +318,6 @@ func findFromAVP(avps []*AVP, code uint32, findMultiple bool) ([]*AVP, error) {
 //	avps, err := m.FindAVPs("Origin-Host")
 //
 func (m *Message) FindAVPs(code interface{}) ([]*AVP, error) {
-
 	dictAVP, err := m.Dictionary().FindAVP(m.Header.ApplicationID, code)
 
 	if err != nil {
@@ -338,7 +337,6 @@ func (m *Message) FindAVPs(code interface{}) ([]*AVP, error) {
 //	avp, err := m.FindAVP("Origin-Host")
 //
 func (m *Message) FindAVP(code interface{}) (*AVP, error) {
-
 	dictAVP, err := m.Dictionary().FindAVP(m.Header.ApplicationID, code)
 
 	if err != nil {
@@ -365,7 +363,6 @@ func (m *Message) Answer(resultCode uint32) *Message {
 		m.Header.EndToEndID,
 		m.Dictionary(),
 	)
-
 	nm.NewAVP(avp.ResultCode, avp.Mbit, 0, datatype.Unsigned32(resultCode))
 	return nm
 }

--- a/diam/message_test.go
+++ b/diam/message_test.go
@@ -136,6 +136,7 @@ func TestNewMessage(t *testing.T) {
 }
 
 func TestMessageFindAVP(t *testing.T) {
+
 	m, _ := ReadMessage(bytes.NewReader(testMessage), dict.Default)
 	a, err := m.FindAVP(avp.OriginStateID)
 	if err != nil {
@@ -146,6 +147,19 @@ func TestMessageFindAVP(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(a)
+
+	a, err = m.FindAVP("Vendor-Id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(a)
+
+	avps := make([]*AVP, 0)
+	avps, err = m.FindAVPs("Supported-Vendor-Id")
+	if err != nil || len(avps) != 2 {
+		t.Fatal(err)
+	}
+	t.Log(avps)
 }
 
 func BenchmarkReadMessage(b *testing.B) {


### PR DESCRIPTION
Unmarshal is functionality is nice when you want to parse multiple AVPs from a message. But in case you want to for example get only one AVP that is deeply nested inside grouped AVPs then unmarshal is a bit clumsy. This commit adds the ability to search within grouped AVPs and also added new search function which can return multiple AVPs.