### PR TITLE
OriginStateID issue and Marshal function 

### DIFF
--- a/diam/reflect.go
+++ b/diam/reflect.go
@@ -15,11 +15,11 @@ import (
 	"github.com/fiorix/go-diameter/diam/dict"
 )
 
-// tagOptions is the string following a comma in a struct field's "json"
+// tagOptions is the string following a comma in a struct field's "avp"
 // tag, or the empty string. It does not include the leading comma.
 type tagOptions string
 
-// parseTag splits a struct field's json tag into its name and
+// parseTag splits a struct field's avp tag into its name and
 // comma-separated options.
 func parseTag(tag string) (string, tagOptions) {
 	if idx := strings.Index(tag, ","); idx != -1 {
@@ -225,9 +225,6 @@ func marshal(m *Message, field reflect.Value, fieldAVP *dict.AVP) (error, []*AVP
 				tag := bt.Tag.Get("avp")
 				avpname, opts := parseTag(tag)
 				omitEmpty := opts.Contains("omitempty")
-				if len(avpname) == 0 || avpname == "-" {
-					continue
-				}
 				if len(avpname) == 0 || avpname == "-" {
 					continue
 				}

--- a/diam/reflect.go
+++ b/diam/reflect.go
@@ -28,7 +28,7 @@ func parseAvpTag(tag reflect.StructTag) (string, bool) {
 			name = name[0 : len(name)-10]
 			omitEmpty = true
 		}
-		if strings.LastIndexByte(name, '"') == -1 {
+		if strings.IndexByte(name, '"') == -1 {
 			return name, omitEmpty
 		}
 	}

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -186,13 +186,12 @@ func (cli *Client) makeCER(ip net.IP) *diam.Message {
 
 func (cli *Client) watchdog(c diam.Conn, dwac chan struct{}) {
 	disconnect := c.(diam.CloseNotifier).CloseNotify()
-	var osid uint32
+	var osid uint32 = uint32(cli.Handler.cfg.OriginStateID)
 	for {
 		select {
 		case <-disconnect:
 			return
 		case <-time.After(cli.WatchdogInterval):
-			osid++
 			cli.dwr(c, osid, dwac)
 		}
 	}

--- a/diam/sm/dwr.go
+++ b/diam/sm/dwr.go
@@ -5,8 +5,6 @@
 package sm
 
 import (
-	"time"
-
 	"github.com/fiorix/go-diameter/diam"
 	"github.com/fiorix/go-diameter/diam/avp"
 	"github.com/fiorix/go-diameter/diam/datatype"

--- a/diam/sm/dwr.go
+++ b/diam/sm/dwr.go
@@ -34,8 +34,10 @@ func handleDWR(sm *StateMachine) diam.HandlerFunc {
 		a := m.Answer(diam.Success)
 		a.NewAVP(avp.OriginHost, avp.Mbit, 0, sm.cfg.OriginHost)
 		a.NewAVP(avp.OriginRealm, avp.Mbit, 0, sm.cfg.OriginRealm)
-		stateid := datatype.Unsigned32(time.Now().Unix())
-		a.NewAVP(avp.OriginStateID, avp.Mbit, 0, stateid)
+		if sm.cfg.OriginStateID != 0 {
+			stateid := datatype.Unsigned32(sm.cfg.OriginStateID)
+			m.NewAVP(avp.OriginStateID, avp.Mbit, 0, stateid)
+		}
 		_, err = a.WriteTo(c)
 		if err != nil {
 			sm.Error(&diam.ErrorReport{

--- a/diam/sm/smparser/app.go
+++ b/diam/sm/smparser/app.go
@@ -96,6 +96,10 @@ func (app *Application) validate(d *dict.Parser, appType uint32, appAVP *diam.AV
 		return appAVP, &ErrUnexpectedAVP{appAVP}
 	}
 	id := uint32(appID)
+	if id == 0xffffffff { // relay application id
+		app.id = append(app.id, id)
+		return nil, nil
+	}
 	avp, err := d.App(id)
 	if err != nil {
 		return appAVP, &ErrNoCommonApplication{id, typ}


### PR DESCRIPTION
When testing  freeDiameter's  relay agent , I found several issues of go-diameter:  

1.  "Application Id" 0xffffffff for relay agent should be supported. See rfc6733  "2.4.  Application Identifiers"

2.  OriginStateID should be consistent in all requests inclulding the DWR, otherwise the remote peer will suppose the local peer has reboot and try to reset the connection.

3.  And I have implement a Marshal function in reflect.go. I think it can simplify the "build request" code .   An example can be found here https://github.com/gmd20/go-diameter




