### PR TITLE
Firmware-Revision AVP encoded incorrectly (AVP Mandatory flag must not be set)

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -87,7 +87,7 @@ func errorCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER,
 		a.AddAVP(cer.OriginStateID)
 	}
 	if sm.cfg.FirmwareRevision != 0 {
-		a.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, sm.cfg.FirmwareRevision)
+		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
 	}
 	_, err = a.WriteTo(c)
 	return err
@@ -130,7 +130,7 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 		}
 	}
 	if sm.cfg.FirmwareRevision != 0 {
-		a.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, sm.cfg.FirmwareRevision)
+		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
 	}
 	_, err = a.WriteTo(c)
 	return err

--- a/diam/sm/cer_test.go
+++ b/diam/sm/cer_test.go
@@ -43,7 +43,7 @@ func TestHandleCER_HandshakeMetadata(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func TestHandleCER_Acct(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +127,7 @@ func TestHandleCER_Acct_Fail(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1000))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -170,7 +170,7 @@ func TestHandleCER_VS_Acct(t *testing.T) {
 			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001)),
 		},
 	})
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -213,7 +213,7 @@ func TestHandleCER_VS_Acct_Fail(t *testing.T) {
 			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1000)),
 		},
 	})
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -252,7 +252,7 @@ func TestHandleCER_Auth(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(1002))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -291,7 +291,7 @@ func TestHandleCER_Auth_Fail(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(1000))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -334,7 +334,7 @@ func TestHandleCER_VS_Auth(t *testing.T) {
 			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(1002)),
 		},
 	})
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -377,7 +377,7 @@ func TestHandleCER_VS_Auth_Fail(t *testing.T) {
 			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(1000)),
 		},
 	})
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -416,7 +416,7 @@ func TestHandleCER_InbandSecurity(t *testing.T) {
 	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -179,7 +179,7 @@ func (cli *Client) makeCER(ip net.IP) *diam.Message {
 		}
 	}
 	if cli.Handler.cfg.FirmwareRevision != 0 {
-		m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, cli.Handler.cfg.FirmwareRevision)
+		m.NewAVP(avp.FirmwareRevision, 0, 0, cli.Handler.cfg.FirmwareRevision)
 	}
 	return m
 }

--- a/diam/sm/dwr_test.go
+++ b/diam/sm/dwr_test.go
@@ -44,7 +44,7 @@ func TestHandleDWR(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)
@@ -106,7 +106,7 @@ func TestHandleDWR_Fail(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)

--- a/diam/sm/sm_test.go
+++ b/diam/sm/sm_test.go
@@ -75,7 +75,7 @@ func TestStateMachine(t *testing.T) {
 	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
 	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
 	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
-	m.NewAVP(avp.FirmwareRevision, avp.Mbit, 0, clientSettings.FirmwareRevision)
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
 	_, err = m.WriteTo(cli)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Firmware-Revision AVP is being encoded incorrectly.   It has the AVP M bit set which is incorrect.

I have a go-diameter client talking to a server, and see this in the CER message from the go-diameter client.

The server side is complaining about Firmware-Revision AVP  with this code : DIAMETER_INVALID_AVP_BITS          3009

@micrypt describes the same problem in #42 

The AVP definition is correct -

<avp name="Firmware-Revision" code="267" must="-" may="-" must-not="P,V,M" may-encrypt="-">


but all of the code creating the FirmwareRevision AVP is setting the M bit 