### PR TITLE
adding timeout for tls dialing

### DIFF
--- a/diam/client.go
+++ b/diam/client.go
@@ -69,7 +69,14 @@ func dialTLS(srv *Server, certFile, keyFile string, timeout time.Duration) (Conn
 			return nil, err
 		}
 	}
-	rw, err := net.DialTimeout("tcp", addr, timeout)
+
+	var rw net.Conn
+	var err error
+	if timeout == 0 {
+		rw, err = net.Dial("tcp", addr)
+	} else {
+		rw, err = net.DialTimeout("tcp", addr, timeout)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/diam/client.go
+++ b/diam/client.go
@@ -9,6 +9,7 @@ package diam
 import (
 	"crypto/tls"
 	"net"
+	"time"
 
 	"github.com/fiorix/go-diameter/diam/dict"
 )
@@ -42,10 +43,16 @@ func dial(srv *Server) (Conn, error) {
 // DialTLS is the same as Dial, but for TLS.
 func DialTLS(addr, certFile, keyFile string, handler Handler, dp *dict.Parser) (Conn, error) {
 	srv := &Server{Addr: addr, Handler: handler, Dict: dp}
-	return dialTLS(srv, certFile, keyFile)
+	return dialTLS(srv, certFile, keyFile, 0)
 }
 
-func dialTLS(srv *Server, certFile, keyFile string) (Conn, error) {
+// DialTLSTimeout is the same as DialTimeout, but for TLS.
+func DialTLSTimeout(addr, certFile, keyFile string, handler Handler, dp *dict.Parser, timeout time.Duration) (Conn, error) {
+	srv := &Server{Addr: addr, Handler: handler, Dict: dp}
+	return dialTLS(srv, certFile, keyFile, timeout)
+}
+
+func dialTLS(srv *Server, certFile, keyFile string, timeout time.Duration) (Conn, error) {
 	addr := srv.Addr
 	if len(addr) == 0 {
 		addr = ":3868"
@@ -62,7 +69,7 @@ func dialTLS(srv *Server, certFile, keyFile string) (Conn, error) {
 			return nil, err
 		}
 	}
-	rw, err := net.Dial("tcp", addr)
+	rw, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -69,6 +69,13 @@ func (cli *Client) DialTLS(addr, certFile, keyFile string) (diam.Conn, error) {
 	})
 }
 
+// DialTLSTimeout is like DialTimeout, but using TLS.
+func (cli *Client) DialTLSTimeout(addr, certFile, keyFile string, timeout time.Duration) (diam.Conn, error) {
+	return cli.dial(func() (diam.Conn, error) {
+		return diam.DialTLSTimeout(addr, certFile, keyFile, cli.Handler, cli.Dict, timeout)
+	})
+}
+
 type dialFunc func() (diam.Conn, error)
 
 func (cli *Client) dial(f dialFunc) (diam.Conn, error) {


### PR DESCRIPTION
In support of https://github.com/fiorix/go-diameter/pull/50 , I have tried client with 1 and 0 nanosecond as timeout. It seems to work on my test server (1 nanosecond connection time out, while setting 0 seems to work like no timeout is set). I took the liberty to try it since last update for https://github.com/fiorix/go-diameter/pull/50 was 4 days ago, it does not replace, but complements pr 50. 