### PR TITLE
removed dependency on parser for supported apps verification

### DIFF
--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/fiorix/go-diameter/diam/avp"
 	"github.com/fiorix/go-diameter/diam/datatype"
 	"github.com/fiorix/go-diameter/diam/dict"
-	//"github.com/fiorix/go-diameter/diam/sm/smparser"
 )
 
 var (
@@ -123,9 +122,8 @@ func (cli *Client) validate() error {
 			}
 		}
 		if isSupported == false {
-			err := fmt.Errorf("Client attempts to advertise unsupported application - type: auth, id: %d", acctAppID)
+			err := fmt.Errorf("Client attempts to advertise unsupported application - type: acct, id: %d", acctAppID)
 			return err
-			//return smparser.ErrMissingApplication
 		}
 
 	}
@@ -141,7 +139,6 @@ func (cli *Client) validate() error {
 		if isSupported == false {
 			err := fmt.Errorf("Client attempts to advertise unsupported application - type: auth, id: %d", authAppID)
 			return err
-			//return smparser.ErrMissingApplication
 		}
 
 	}

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fiorix/go-diameter/diam/avp"
 	"github.com/fiorix/go-diameter/diam/datatype"
 	"github.com/fiorix/go-diameter/diam/dict"
+	//"github.com/fiorix/go-diameter/diam/sm/smparser"
 )
 
 var (
@@ -62,6 +63,7 @@ func (cli *Client) Dial(addr string) (diam.Conn, error) {
 	})
 }
 
+// DialTimeout is like Dial, but with timeout
 func (cli *Client) DialTimeout(addr string, timeout time.Duration) (diam.Conn, error) {
 	return cli.dial(func() (diam.Conn, error) {
 		return diam.DialTimeout(addr, cli.Handler, cli.Dict, timeout)
@@ -121,8 +123,9 @@ func (cli *Client) validate() error {
 			}
 		}
 		if isSupported == false {
-			err := fmt.Errorf("Client attempts to advertise unsupported application - type: acct, id: %d", acctAppID)
+			err := fmt.Errorf("Client attempts to advertise unsupported application - type: auth, id: %d", acctAppID)
 			return err
+			//return smparser.ErrMissingApplication
 		}
 
 	}
@@ -138,6 +141,7 @@ func (cli *Client) validate() error {
 		if isSupported == false {
 			err := fmt.Errorf("Client attempts to advertise unsupported application - type: auth, id: %d", authAppID)
 			return err
+			//return smparser.ErrMissingApplication
 		}
 
 	}

--- a/diam/sm/client_test.go
+++ b/diam/sm/client_test.go
@@ -27,14 +27,6 @@ func TestClient_Dial_MissingStateMachine(t *testing.T) {
 	}
 }
 
-func TestClient_Dial_MissingApplication(t *testing.T) {
-	cli := &Client{Handler: New(&Settings{})}
-	_, err := cli.Dial("")
-	if err != smparser.ErrMissingApplication {
-		t.Fatal(err)
-	}
-}
-
 func TestClient_Dial_InvalidAddress(t *testing.T) {
 	cli := &Client{
 		Handler: New(clientSettings),
@@ -73,15 +65,15 @@ func TestClient_Handshake(t *testing.T) {
 			diam.NewAVP(avp.SupportedVendorID, avp.Mbit, 0, clientSettings.VendorID),
 		},
 		AcctApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
 		},
 		AuthApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4)),
 		},
 		VendorSpecificApplicationID: []*diam.AVP{
 			diam.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
 				AVP: []*diam.AVP{
-					diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+					diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4)),
 				},
 			}),
 		},
@@ -102,15 +94,15 @@ func TestClient_Handshake_Notify(t *testing.T) {
 			diam.NewAVP(avp.SupportedVendorID, avp.Mbit, 0, clientSettings.VendorID),
 		},
 		AcctApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
 		},
 		AuthApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4)),
 		},
 		VendorSpecificApplicationID: []*diam.AVP{
 			diam.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
 				AVP: []*diam.AVP{
-					diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+					diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4)),
 				},
 			}),
 		},
@@ -144,7 +136,7 @@ func TestClient_Handshake_FailParseCEA(t *testing.T) {
 	cli := &Client{
 		Handler: New(clientSettings),
 		AcctApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
 		},
 	}
 	_, err := cli.Dial(srv.Addr)
@@ -174,7 +166,7 @@ func TestClient_Handshake_FailedResultCode(t *testing.T) {
 	cli := &Client{
 		Handler: New(clientSettings),
 		AcctApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
 		},
 	}
 	_, err := cli.Dial(srv.Addr)
@@ -204,7 +196,7 @@ func TestClient_Handshake_RetransmitTimeout(t *testing.T) {
 		MaxRetransmits:     3,
 		RetransmitInterval: time.Millisecond,
 		AcctApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
 		},
 	}
 	_, err := cli.Dial(srv.Addr)
@@ -227,7 +219,7 @@ func TestClient_Watchdog(t *testing.T) {
 		WatchdogInterval: 100 * time.Millisecond,
 		Handler:          New(clientSettings),
 		AcctApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
 		},
 	}
 	c, err := cli.Dial(srv.Addr)
@@ -262,7 +254,7 @@ func TestClient_Watchdog_Timeout(t *testing.T) {
 		WatchdogInterval:   50 * time.Millisecond,
 		Handler:            New(clientSettings),
 		AcctApplicationID: []*diam.AVP{
-			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(0)),
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
 		},
 	}
 	c, err := cli.Dial(srv.Addr)

--- a/diam/sm/smparser/cea_test.go
+++ b/diam/sm/smparser/cea_test.go
@@ -118,7 +118,7 @@ func TestCEA(t *testing.T) {
 			diam.Success, cea.ResultCode)
 	}
 	if cea.OriginStateID != 1 {
-		t.Fatalf("Unexpected Result-Code. Want 1, have %d", cea.OriginStateID)
+		t.Fatalf("Unexpected Origin-State-ID. Want 1, have %d", cea.OriginStateID)
 	}
 	if app := cea.Applications(); len(app) != 1 {
 		if app[0] != 4 {


### PR DESCRIPTION
This one has the following goals:
- fix error message to user when client is initialized with apps unsupported locally (an issue introduced in https://github.com/fiorix/go-diameter/pull/56 and mentioned in https://github.com/fiorix/go-diameter/issues/61) - can be fixed by other means but current one seems natural
- make use of sm.supportedApps which is used for supported apps verification on the server side

It has 2 potential downsides:
- sm and sm client can be initialized with different dictionaries (however it does not seem likely)
- fmt dependency is added (though it makes it possible to generate very descriptive message to library user )