### PR TITLE
Add more error details for CEA failure

### DIFF
--- a/diam/sm/smparser/cea.go
+++ b/diam/sm/smparser/cea.go
@@ -29,13 +29,12 @@ type CEA struct {
 // ErrFailedResultCode is returned by Dial or DialTLS when the handshake
 // answer (CEA) contains a Result-Code AVP that is not success (2001).
 type ErrFailedResultCode struct {
-	Code uint32
-	Cea  *CEA
+	*CEA
 }
 
 // Error implements the error interface.
-func (e *ErrFailedResultCode) Error() string {
-	return fmt.Sprintf("failed Result-Code AVP: %d", e.Code)
+func (e ErrFailedResultCode) Error() string {
+	return fmt.Sprintf("failed Result-Code AVP: %d", e.CEA.ResultCode)
 }
 
 // Parse parses and validates the given message.
@@ -47,7 +46,7 @@ func (cea *CEA) Parse(m *diam.Message, localRole Role) (err error) {
 		return err
 	}
 	if cea.ResultCode != diam.Success {
-		return &ErrFailedResultCode{Code: cea.ResultCode, Cea: cea}
+		return &ErrFailedResultCode{CEA: cea}
 	}
 	app := &Application{
 		AcctApplicationID:           cea.AcctApplicationID,


### PR DESCRIPTION
_Result-Code_ was not enough to identify some error cases. In one case, the code is a generic "DIAMETER_UNABLE_TO_COMPLY" and the specific error is in the _Error-Message_ AVP:

```
	Result-Code {Code:268,Flags:0x40,Length:12,VendorId:0,Value:Unsigned32{5012}}
	Error-Message {Code:281,Flags:0x0,Length:40,VendorId:0,Value:UTF8String{Origin-Host already connected},Padding:3}
```

This PR:
- adds _Failed-AVP_ and _Error-Message_ to CEA struct
- exposes CEA in ErrFailedResultCode