### PR TITLE
Nil pointer fix for sm/cer.go

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -76,6 +76,8 @@ func errorCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER,
 		a = m.Answer(diam.NoCommonSecurity)
 	case smparser.ErrNoCommonApplication:
 		a = m.Answer(diam.NoCommonApplication)
+	default:
+		a = m.Answer(diam.UnableToComply)
 	}
 	a.Header.CommandFlags |= diam.ErrorFlag
 	a.NewAVP(avp.OriginHost, avp.Mbit, 0, sm.cfg.OriginHost)


### PR DESCRIPTION
I'm making some client-server test cases and got a panic on `github.com/fiorix/go-diameter/diam/sm/cer.go:80`. I'm missing the _Origin-host_ AVP and that causes an error of type _errors.errorString_ which wasn't handled by the switch case.
