### PR TITLE
Allow clients to provide a pre-defined ip address.

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -66,10 +66,17 @@ func handleCER(sm *StateMachine) diam.HandlerFunc {
 // an unsupported (acct/auth) application, and includes the AVP that
 // caused the failure in the message.
 func errorCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER, errMessage error) error {
-	hostIP, _, err := net.SplitHostPort(c.LocalAddr().String())
-	if err != nil {
-		return fmt.Errorf("failed to parse own ip %q: %s", c.LocalAddr(), err)
+	var hostAddress datatype.Address
+	if len(sm.cfg.HostIPAdress) > 0 {
+		hostAddress = sm.cfg.HostIPAdress
+	} else {
+		hostIP, _, err := net.SplitHostPort(c.LocalAddr().String())
+		if err != nil {
+			return fmt.Errorf("failed to parse own ip %q: %s", c.LocalAddr(), err)
+		}
+		hostAddress = datatype.Address(net.ParseIP(hostIP))
 	}
+
 	var a *diam.Message
 	switch errMessage {
 	case smparser.ErrNoCommonSecurity:
@@ -82,7 +89,7 @@ func errorCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER,
 	a.Header.CommandFlags |= diam.ErrorFlag
 	a.NewAVP(avp.OriginHost, avp.Mbit, 0, sm.cfg.OriginHost)
 	a.NewAVP(avp.OriginRealm, avp.Mbit, 0, sm.cfg.OriginRealm)
-	a.NewAVP(avp.HostIPAddress, avp.Mbit, 0, datatype.Address(net.ParseIP(hostIP)))
+	a.NewAVP(avp.HostIPAddress, avp.Mbit, 0, hostAddress)
 	a.NewAVP(avp.VendorID, avp.Mbit, 0, sm.cfg.VendorID)
 	a.NewAVP(avp.ProductName, 0, 0, sm.cfg.ProductName)
 	if cer.OriginStateID != nil {
@@ -91,21 +98,27 @@ func errorCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER,
 	if sm.cfg.FirmwareRevision != 0 {
 		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
 	}
-	_, err = a.WriteTo(c)
+	_, err := a.WriteTo(c)
 	return err
 }
 
 // successCEA sends a success answer indicating that the CER was successfully
 // parsed and accepted by the server.
 func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER) error {
-	hostIP, _, err := net.SplitHostPort(c.LocalAddr().String())
-	if err != nil {
-		return fmt.Errorf("failed to parse own ip %q: %s", c.LocalAddr(), err)
+	var hostAddress datatype.Address
+	if len(sm.cfg.HostIPAdress) > 0 {
+		hostAddress = sm.cfg.HostIPAdress
+	} else {
+		hostIP, _, err := net.SplitHostPort(c.LocalAddr().String())
+		if err != nil {
+			return fmt.Errorf("failed to parse own ip %q: %s", c.LocalAddr(), err)
+		}
+		hostAddress = datatype.Address(net.ParseIP(hostIP))
 	}
 	a := m.Answer(diam.Success)
 	a.NewAVP(avp.OriginHost, avp.Mbit, 0, sm.cfg.OriginHost)
 	a.NewAVP(avp.OriginRealm, avp.Mbit, 0, sm.cfg.OriginRealm)
-	a.NewAVP(avp.HostIPAddress, avp.Mbit, 0, datatype.Address(net.ParseIP(hostIP)))
+	a.NewAVP(avp.HostIPAddress, avp.Mbit, 0, hostAddress)
 	a.NewAVP(avp.VendorID, avp.Mbit, 0, sm.cfg.VendorID)
 	a.NewAVP(avp.ProductName, 0, 0, sm.cfg.ProductName)
 	if cer.OriginStateID != nil {
@@ -134,6 +147,6 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 	if sm.cfg.FirmwareRevision != 0 {
 		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
 	}
-	_, err = a.WriteTo(c)
+	_, err := a.WriteTo(c)
 	return err
 }

--- a/diam/sm/cer_test.go
+++ b/diam/sm/cer_test.go
@@ -66,6 +66,54 @@ func TestHandleCER_HandshakeMetadata(t *testing.T) {
 	}
 }
 
+func TestHandleCER_HandshakeMetadata_CustomIP(t *testing.T) {
+	sm := New(serverSettings2)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+	hsc := make(chan diam.Conn, 1)
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		c := <-sm.HandshakeNotify()
+		hsc <- c
+	}()
+	<-ready
+	m := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	_, err = m.WriteTo(cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case c := <-hsc:
+		ctx := c.Context()
+		meta, ok := smpeer.FromContext(ctx)
+		if !ok {
+			t.Fatal("Handshake ok but no context/metadata found")
+		}
+		if meta.OriginHost != clientSettings.OriginHost {
+			t.Fatalf("Unexpected OriginHost. Want %q, have %q",
+				clientSettings.OriginHost, meta.OriginHost)
+		}
+		if meta.OriginRealm != clientSettings.OriginRealm {
+			t.Fatalf("Unexpected OriginRealm. Want %q, have %q",
+				clientSettings.OriginRealm, meta.OriginRealm)
+		}
+	}
+}
+
 func TestHandleCER_Acct(t *testing.T) {
 	sm := New(serverSettings)
 	srv := diamtest.NewServer(sm, dict.Default)
@@ -107,6 +155,45 @@ func TestHandleCER_Acct(t *testing.T) {
 
 func TestHandleCER_Acct_Fail(t *testing.T) {
 	sm := New(serverSettings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+	mc := make(chan *diam.Message, 1)
+	mux := diam.NewServeMux()
+	mux.HandleFunc("CEA", func(c diam.Conn, m *diam.Message) {
+		mc <- m
+	})
+	cli, err := diam.Dial(srv.Addr, mux, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+	m := diam.NewRequest(diam.CapabilitiesExchange, 0, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1000))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	_, err = m.WriteTo(cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case resp := <-mc:
+		if !testResultCode(resp, diam.NoCommonApplication) {
+			t.Fatalf("Unexpected result code.\n%s", resp)
+		}
+	case err := <-mux.ErrorReports():
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("No message received")
+	}
+}
+
+func TestHandleCER_Acct_Fail_CustomIP(t *testing.T) {
+	sm := New(serverSettings2)
 	srv := diamtest.NewServer(sm, dict.Default)
 	defer srv.Close()
 	mc := make(chan *diam.Message, 1)

--- a/diam/sm/client_test.go
+++ b/diam/sm/client_test.go
@@ -85,6 +85,35 @@ func TestClient_Handshake(t *testing.T) {
 	c.Close()
 }
 
+func TestClient_Handshake_CustomIP(t *testing.T) {
+	srv := diamtest.NewServer(New(serverSettings), dict.Default)
+	defer srv.Close()
+	cli := &Client{
+		Handler: New(clientSettings2),
+		SupportedVendorID: []*diam.AVP{
+			diam.NewAVP(avp.SupportedVendorID, avp.Mbit, 0, clientSettings.VendorID),
+		},
+		AcctApplicationID: []*diam.AVP{
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
+		},
+		AuthApplicationID: []*diam.AVP{
+			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4)),
+		},
+		VendorSpecificApplicationID: []*diam.AVP{
+			diam.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
+				AVP: []*diam.AVP{
+					diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4)),
+				},
+			}),
+		},
+	}
+	c, err := cli.Dial(srv.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Close()
+}
+
 func TestClient_Handshake_Notify(t *testing.T) {
 	srv := diamtest.NewServer(New(serverSettings), dict.Default)
 	defer srv.Close()

--- a/diam/sm/common_test.go
+++ b/diam/sm/common_test.go
@@ -44,6 +44,16 @@ var (
 		FirmwareRevision: 1,
 	}
 
+	serverSettings2 = &Settings{
+		OriginHost:       "srv2",
+		OriginRealm:      "test2",
+		VendorID:         13,
+		ProductName:      "go-diameter",
+		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
+		FirmwareRevision: 1,
+		HostIPAdress:     localhostAddress,
+	}
+
 	clientSettings = &Settings{
 		OriginHost:       "cli",
 		OriginRealm:      "test",
@@ -51,5 +61,15 @@ var (
 		ProductName:      "go-diameter",
 		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
 		FirmwareRevision: 1,
+	}
+
+	clientSettings2 = &Settings{
+		OriginHost:       "cli2",
+		OriginRealm:      "test2",
+		VendorID:         13,
+		ProductName:      "go-diameter",
+		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
+		FirmwareRevision: 1,
+		HostIPAdress:     localhostAddress,
 	}
 )

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -41,10 +41,11 @@ func PrepareSupportedApps(d *dict.Parser) []*SupportedApp {
 // Settings used to configure the state machine with AVPs to be added
 // to CER on clients or CEA on servers.
 type Settings struct {
-	OriginHost  datatype.DiameterIdentity
-	OriginRealm datatype.DiameterIdentity
-	VendorID    datatype.Unsigned32
-	ProductName datatype.UTF8String
+	OriginHost   datatype.DiameterIdentity
+	OriginRealm  datatype.DiameterIdentity
+	HostIPAdress datatype.Address
+	VendorID     datatype.Unsigned32
+	ProductName  datatype.UTF8String
 
 	// OriginStateID is optional for clients, and not added if unset.
 	//

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -41,11 +41,10 @@ func PrepareSupportedApps(d *dict.Parser) []*SupportedApp {
 // Settings used to configure the state machine with AVPs to be added
 // to CER on clients or CEA on servers.
 type Settings struct {
-	OriginHost   datatype.DiameterIdentity
-	OriginRealm  datatype.DiameterIdentity
-	HostIPAdress datatype.Address
-	VendorID     datatype.Unsigned32
-	ProductName  datatype.UTF8String
+	OriginHost  datatype.DiameterIdentity
+	OriginRealm datatype.DiameterIdentity
+	VendorID    datatype.Unsigned32
+	ProductName datatype.UTF8String
 
 	// OriginStateID is optional for clients, and not added if unset.
 	//
@@ -57,6 +56,14 @@ type Settings struct {
 
 	// FirmwareRevision is optional, and not added if unset.
 	FirmwareRevision datatype.Unsigned32
+
+	// HostIPAdress is optional for both clients and servers, when not set local
+	// host IP address is used.
+	//
+	// This property may be set when the IP address of the host sending/receiving
+	// the request is different from the configured allowed IPs in the other end,
+	// for example when using a VPN or a gateway.
+	HostIPAdress datatype.Address
 }
 
 // StateMachine is a specialized type of diam.ServeMux that handles


### PR DESCRIPTION
In some cases the requests might be fired from different machines via a gateway
or a NAT, local IP might not match the rules defined in the diameter server side.