### PR TITLE
close correct connection in cleanupConn

### DIFF
--- a/examples/s6a_proxy/service/util.go
+++ b/examples/s6a_proxy/service/util.go
@@ -92,7 +92,7 @@ func (s *s6aProxy) cleanupConn(c diam.Conn) {
 		s.conn = nil
 	}
 	s.mu.Unlock()
-	s.conn.Close()
+	c.Close()
 }
 
 // TranslateBaseDiamResultCode maps Base Diameter Result Code to GRPC Status Error and returns it,


### PR DESCRIPTION
I think this patch fixes a minor issue when releasing a connection. With the patch, we never call close a nil-object.

Note: this has been found from manual inspection, we did not reproduce the failure.