### PR TITLE
support multiple Host-IP-Address AVPs in CER and CEA

### DIFF
--- a/diam/dict/testdata/base.xml
+++ b/diam/dict/testdata/base.xml
@@ -7,7 +7,7 @@
 			<request>
 				<rule avp="Origin-Host" required="true" max="1"/>
 				<rule avp="Origin-Realm" required="true" max="1"/>
-				<rule avp="Host-IP-Address" required="true" max="1"/>
+				<rule avp="Host-IP-Address" required="true" min="1"/>
 				<rule avp="Vendor-Id" required="true" max="1"/>
 				<rule avp="Product-Name" required="true" max="1"/>
 				<rule avp="Origin-State-Id" required="false" max="1"/>
@@ -22,7 +22,7 @@
 				<rule avp="Result-Code" required="true" max="1"/>
 				<rule avp="Origin-Host" required="true" max="1"/>
 				<rule avp="Origin-Realm" required="true" max="1"/>
-				<rule avp="Host-IP-Address" required="true" max="1"/>
+				<rule avp="Host-IP-Address" required="true" min="1"/>
 				<rule avp="Vendor-Id" required="true" max="1"/>
 				<rule avp="Product-Name" required="true" max="1"/>
 				<rule avp="Origin-State-Id" required="false" max="1"/>

--- a/diam/sm/common_test.go
+++ b/diam/sm/common_test.go
@@ -51,7 +51,7 @@ var (
 		ProductName:      "go-diameter",
 		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
 		FirmwareRevision: 1,
-		HostIPAddress:    localhostAddress,
+		HostIPAddresses:  []datatype.Address{localhostAddress},
 	}
 
 	clientSettings = &Settings{
@@ -70,6 +70,6 @@ var (
 		ProductName:      "go-diameter",
 		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
 		FirmwareRevision: 1,
-		HostIPAddress:    localhostAddress,
+		HostIPAddresses:  []datatype.Address{localhostAddress},
 	}
 )

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -63,7 +63,7 @@ type Settings struct {
 	// This property may be set when the IP address of the host sending/receiving
 	// the request is different from the configured allowed IPs in the other end,
 	// for example when using a VPN or a gateway.
-	HostIPAddress datatype.Address
+	HostIPAddresses []datatype.Address
 }
 
 var (


### PR DESCRIPTION
CER and CEA definitions require Host-IP-Address AVP as following in RFC 6733 Diameter Base Protocol:
`1* { Host-IP-Address }`
This means Host-IP-Address AVP should appear at least once, and it is allowed to appear multiple times.

In the real world HLR usage, we need multiple Host-IP-Address APVs for redundancy.