### PR TITLE
Support multiple Host-IP-Address APVs in CER and CEA

### DIFF
--- a/diam/dict/testdata/base.xml
+++ b/diam/dict/testdata/base.xml
@@ -7,7 +7,7 @@
 			<request>
 				<rule avp="Origin-Host" required="true" max="1"/>
 				<rule avp="Origin-Realm" required="true" max="1"/>
-				<rule avp="Host-IP-Address" required="true" max="1"/>
+				<rule avp="Host-IP-Address" required="true" min="1"/>
 				<rule avp="Vendor-Id" required="true" max="1"/>
 				<rule avp="Product-Name" required="true" max="1"/>
 				<rule avp="Origin-State-Id" required="false" max="1"/>
@@ -22,7 +22,7 @@
 				<rule avp="Result-Code" required="true" max="1"/>
 				<rule avp="Origin-Host" required="true" max="1"/>
 				<rule avp="Origin-Realm" required="true" max="1"/>
-				<rule avp="Host-IP-Address" required="true" max="1"/>
+				<rule avp="Host-IP-Address" required="true" min="1"/>
 				<rule avp="Vendor-Id" required="true" max="1"/>
 				<rule avp="Product-Name" required="true" max="1"/>
 				<rule avp="Origin-State-Id" required="false" max="1"/>

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -172,17 +172,18 @@ func (cli *Client) validate() error {
 }
 
 func (cli *Client) handshake(c diam.Conn) (diam.Conn, error) {
-	var ipAddress datatype.Address
-	if len(cli.Handler.cfg.HostIPAddress) > 0 {
-		ipAddress = cli.Handler.cfg.HostIPAddress
+	var hostAddresses []datatype.Address
+	if len(cli.Handler.cfg.HostIPAddresses) > 0 {
+		hostAddresses = cli.Handler.cfg.HostIPAddresses
 	} else {
-		ip, _, err := net.SplitHostPort(c.LocalAddr().String())
+		hostIP, _, err := net.SplitHostPort(c.LocalAddr().String())
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse own ip %q: %s", c.LocalAddr(), err)
 		}
-		ipAddress = datatype.Address(net.ParseIP(ip))
+		hostAddresses = []datatype.Address{datatype.Address(net.ParseIP(hostIP))}
 	}
-	m := cli.makeCER(ipAddress)
+
+	m := cli.makeCER(hostAddresses)
 	// Ignore CER, but not DWR.
 	cerClientHandler := func(c diam.Conn, m *diam.Message) {}
 	// See sm.go for Base Diam Idx declarations
@@ -219,11 +220,13 @@ func (cli *Client) handshake(c diam.Conn) (diam.Conn, error) {
 	return nil, ErrHandshakeTimeout
 }
 
-func (cli *Client) makeCER(ip datatype.Address) *diam.Message {
+func (cli *Client) makeCER(hostIPAddresses []datatype.Address) *diam.Message {
 	m := diam.NewRequest(diam.CapabilitiesExchange, 0, cli.Dict)
 	m.NewAVP(avp.OriginHost, avp.Mbit, 0, cli.Handler.cfg.OriginHost)
 	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, cli.Handler.cfg.OriginRealm)
-	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, ip)
+	for _, hostIPAddress := range hostIPAddresses {
+		m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, hostIPAddress)
+	}
 	m.NewAVP(avp.VendorID, avp.Mbit, 0, cli.Handler.cfg.VendorID)
 	m.NewAVP(avp.ProductName, 0, 0, cli.Handler.cfg.ProductName)
 	if cli.Handler.cfg.OriginStateID != 0 {

--- a/diam/sm/common_test.go
+++ b/diam/sm/common_test.go
@@ -51,7 +51,7 @@ var (
 		ProductName:      "go-diameter",
 		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
 		FirmwareRevision: 1,
-		HostIPAddress:    localhostAddress,
+		HostIPAddresses:  []datatype.Address{localhostAddress},
 	}
 
 	clientSettings = &Settings{
@@ -70,6 +70,6 @@ var (
 		ProductName:      "go-diameter",
 		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
 		FirmwareRevision: 1,
-		HostIPAddress:    localhostAddress,
+		HostIPAddresses:  []datatype.Address{localhostAddress},
 	}
 )

--- a/diam/sm/s6a_client_server_test.go
+++ b/diam/sm/s6a_client_server_test.go
@@ -100,7 +100,7 @@ func testS6aClientServer(network string, t *testing.T) {
 		ProductName:      "go-diameter-s6a",
 		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
 		FirmwareRevision: 1,
-		HostIPAddress:    datatype.Address(net.ParseIP("127.0.0.1")),
+		HostIPAddresses:  []datatype.Address{datatype.Address(net.ParseIP("127.0.0.1"))},
 	}
 
 	// Create the state machine (it's a diam.ServeMux) and client.

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -63,7 +63,7 @@ type Settings struct {
 	// This property may be set when the IP address of the host sending/receiving
 	// the request is different from the configured allowed IPs in the other end,
 	// for example when using a VPN or a gateway.
-	HostIPAddress datatype.Address
+	HostIPAddresses []datatype.Address
 }
 
 var (


### PR DESCRIPTION
CER and CEA definitions require Host-IP-Address AVP as following in RFC 6733 Diameter Base Protocol:
`1* { Host-IP-Address }`
This means Host-IP-Address AVP should appear at least once, and it is allowed to appear multiple times.

In the real world HLR usage, we need multiple Host-IP-Address APVs for redundancy.