### PR TITLE
support binding local address

### DIFF
--- a/diam/client.go
+++ b/diam/client.go
@@ -20,12 +20,17 @@ import (
 // If dict is nil, dict.Default is used.
 func DialNetwork(network, addr string, handler Handler, dp *dict.Parser) (Conn, error) {
 	srv := &Server{Network: network, Addr: addr, Handler: handler, Dict: dp}
-	return dial(srv, 0)
+	return dial(srv, "", 0)
+}
+
+func DialNetworkBind(network, laddr, raddr string, handler Handler, dp *dict.Parser) (Conn, error) {
+	srv := &Server{Network: network, Addr: raddr, Handler: handler, Dict: dp}
+	return dial(srv, laddr, 0)
 }
 
 func DialNetworkTimeout(network, addr string, handler Handler, dp *dict.Parser, timeout time.Duration) (Conn, error) {
 	srv := &Server{Network: network, Addr: addr, Handler: handler, Dict: dp}
-	return dial(srv, timeout)
+	return dial(srv, "", timeout)
 }
 
 // Dial connects to the peer pointed to by addr and returns the Conn that
@@ -41,7 +46,7 @@ func DialTimeout(addr string, handler Handler, dp *dict.Parser, timeout time.Dur
 }
 
 // dial network wrapper
-func dial(srv *Server, timeout time.Duration) (Conn, error) {
+func dial(srv *Server, laddr string, timeout time.Duration) (Conn, error) {
 	network := srv.Network
 	if len(network) == 0 {
 		network = "tcp"
@@ -52,7 +57,7 @@ func dial(srv *Server, timeout time.Duration) (Conn, error) {
 	}
 	var rw net.Conn
 	var err error
-	dialer := getDialer(network, timeout)
+	dialer := getDialer(network, laddr, timeout)
 	rw, err = dialer.Dial(network, addr)
 	if err != nil {
 		return nil, err
@@ -109,7 +114,7 @@ func dialTLS(srv *Server, certFile, keyFile string, timeout time.Duration) (Conn
 	}
 
 	var rw net.Conn
-	dialer := getDialer(network, timeout)
+	dialer := getDialer(network, "", timeout)
 	rw, err = dialer.Dial(network, addr)
 	if err != nil {
 		return nil, err

--- a/diam/network.go
+++ b/diam/network.go
@@ -1,29 +1,44 @@
 package diam
 
 import (
-	"github.com/ishidawataru/sctp"
 	"net"
 	"time"
+
+	"github.com/ishidawataru/sctp"
 )
 
 type Dialer interface {
 	Dial(network, address string) (net.Conn, error)
 }
 
-type sctpDialer struct{}
+type sctpDialer struct {
+	laddr string
+}
 
-func (_ sctpDialer) Dial(network, address string) (net.Conn, error) {
-	sctpAddr, err := sctp.ResolveSCTPAddr(network, address)
+func (d sctpDialer) Dial(network, raddr string) (net.Conn, error) {
+	var (
+		sctpLAddr *sctp.SCTPAddr
+		err       error
+	)
+
+	if d.laddr != "" {
+		sctpLAddr, err = sctp.ResolveSCTPAddr(network, d.laddr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sctpRAddr, err := sctp.ResolveSCTPAddr(network, raddr)
 	if err != nil {
 		return nil, err
 	}
-	return sctp.DialSCTP(network, nil, sctpAddr)
+	return sctp.DialSCTP(network, sctpLAddr, sctpRAddr)
 }
 
-func getDialer(network string, timeout time.Duration) Dialer {
+func getDialer(network string, laddr string, timeout time.Duration) Dialer {
 	switch network {
 	case "sctp", "sctp4", "sctp6":
-		return sctpDialer{}
+		return sctpDialer{laddr: laddr}
 	default:
 		return &net.Dialer{Timeout: timeout}
 	}

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -73,6 +73,14 @@ func (cli *Client) DialNetwork(network, addr string) (diam.Conn, error) {
 	})
 }
 
+// DialNetworkBind calls the network address set as ip:port, performs a handshake and optionally
+// start a watchdog goroutine in background.
+func (cli *Client) DialNetworkBind(network, laddr, raddr string) (diam.Conn, error) {
+	return cli.dial(func() (diam.Conn, error) {
+		return diam.DialNetworkBind(network, laddr, raddr, cli.Handler, cli.Dict)
+	})
+}
+
 // DialTimeout is like Dial, but with timeout
 func (cli *Client) DialTimeout(addr string, timeout time.Duration) (diam.Conn, error) {
 	return cli.dial(func() (diam.Conn, error) {


### PR DESCRIPTION
This PR enables to use `sctp.DialSCTP()` with laddr (local address) to bind a particular IP address and a port number on client side.
Some DRAs requires their clients to use a specified source IP address and port number.