### PR TITLE
Make ResultCode optional when creating an Answer from Message

### DIFF
--- a/diam/message.go
+++ b/diam/message.go
@@ -479,8 +479,8 @@ func (m *Message) FindAVPsWithPath(path []interface{}, vendorID uint32) ([]*AVP,
 	return avpsWithPath(m.AVP, pathCodes), nil
 }
 
-// Answer creates an answer for the current Message with an embedded
-// Result-Code AVP.
+// Answer creates an answer for the current Message
+// with optinal ResultCode
 func (m *Message) Answer(resultCode uint32) *Message {
 	nm := NewMessage(
 		m.Header.CommandCode,
@@ -490,7 +490,9 @@ func (m *Message) Answer(resultCode uint32) *Message {
 		m.Header.EndToEndID,
 		m.Dictionary(),
 	)
-	nm.NewAVP(avp.ResultCode, avp.Mbit, 0, datatype.Unsigned32(resultCode))
+	if resultCode != 0 {
+		nm.NewAVP(avp.ResultCode, avp.Mbit, 0, datatype.Unsigned32(resultCode))
+	}
 	nm.stream = m.stream
 	return nm
 }

--- a/diam/message.go
+++ b/diam/message.go
@@ -480,7 +480,7 @@ func (m *Message) FindAVPsWithPath(path []interface{}, vendorID uint32) ([]*AVP,
 }
 
 // Answer creates an answer for the current Message
-// with optinal ResultCode
+// with optinal ResultCode AVP
 func (m *Message) Answer(resultCode uint32) *Message {
 	nm := NewMessage(
 		m.Header.CommandCode,


### PR DESCRIPTION
According to RFC 4006 Section 3.2 ( https://tools.ietf.org/html/rfc4006#section-3.2 ) the first field should be Session_Id not ResultCode.
With this PR the ResultCode AVP is now optional.