### PR TITLE
Change smparser.Parse() to continue iterating over all VendorSpecificApplicationIDs to capture all supported app IDs

### DIFF
--- a/diam/diamtest/server_sctp_test.go
+++ b/diam/diamtest/server_sctp_test.go
@@ -1,0 +1,14 @@
+// +build linux,!386
+
+// Copyright 2013-2020 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package diamtest
+
+import "testing"
+
+func TestNewServerSCTP(t *testing.T) {
+	srv := NewServerNetwork("sctp", nil, nil)
+	srv.Close()
+}

--- a/diam/diamtest/server_test.go
+++ b/diam/diamtest/server_test.go
@@ -16,8 +16,3 @@ func TestNewServerTLS(t *testing.T) {
 	srv.StartTLS()
 	srv.Close()
 }
-
-func TestNewServerSCTP(t *testing.T) {
-	srv := NewServerNetwork("sctp", nil, nil)
-	srv.Close()
-}

--- a/diam/network_sctp.go
+++ b/diam/network_sctp.go
@@ -1,3 +1,7 @@
+// Copyright 2013-2020 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package diam
 
 import (

--- a/diam/sm/cer_sctp_test.go
+++ b/diam/sm/cer_sctp_test.go
@@ -1,0 +1,13 @@
+// +build linux,!386
+
+// Copyright 2013-2015 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package sm
+
+import "testing"
+
+func TestHandleCER_VS_AuthSCTP(t *testing.T) {
+	testHandleCER_VS_Auth(t, "sctp")
+}

--- a/diam/sm/cer_test.go
+++ b/diam/sm/cer_test.go
@@ -406,10 +406,6 @@ func TestHandleCER_VS_AuthTCP(t *testing.T) {
 	testHandleCER_VS_Auth(t, "tcp")
 }
 
-func TestHandleCER_VS_AuthSCTP(t *testing.T) {
-	testHandleCER_VS_Auth(t, "sctp")
-}
-
 func testHandleCER_VS_Auth(t *testing.T, network string) {
 	sm := New(serverSettings)
 	srv := diamtest.NewServerNetwork(network, sm, dict.Default)


### PR DESCRIPTION
Change smparser.Parse() to continue iterating over all VendorSpecificApplicationIDs to capture all supported app IDs.
Disable failing SCTP unit tests on OSes not supporting SCTP.