### PR TITLE
Continue the validate loop to the next Auth Application ID

### DIFF
--- a/diam/sm/smparser/app.go
+++ b/diam/sm/smparser/app.go
@@ -120,7 +120,7 @@ func (app *Application) validate(d *dict.Parser, appType uint32, appAVP *diam.AV
 	if err != nil {
 		//TODO Log informational message to console?
 	} else if len(avp.Type) > 0 && avp.Type != typ {
-		return nil, ErrNoCommonApplication
+		//TODO Log informational message to console?
 	} else {
 		app.id = append(app.id, id)
 	}


### PR DESCRIPTION
While validating the common application IDs in CEA, the diameter library breaks out with the first non common application ID. Due to this even if there is a common application further in the Auth-Application-ID Avp list in CEA, the diameter library returns a "No Common Application" error code to the application.
<img width="711" alt="Screen Shot 2020-01-20 at 5 19 13 PM" src="https://user-images.githubusercontent.com/48265190/72715861-3baf9d80-3bac-11ea-87ec-4aae03aba313.png">
<img width="742" alt="Screen Shot 2020-01-20 at 5 18 19 PM" src="https://user-images.githubusercontent.com/48265190/72715862-3baf9d80-3bac-11ea-82a6-311a10fd09eb.png">

As seen from the images, the app id 4 is in the Auth Application ID list but still I get following error.

session_proxy | E0120 08:41:44.000333 1 connection.go:51] Failed to establish new tcp diameter connection from '10.17.115.18:3880' to '10.16.26.77:36553'; error: no common application, will retry later.

FIX:
go-diameter/diam/sm/smparser/app.go instead of returning, we can let the loop continue to the next auth application id instead of return nil, ErrNoCommonApplication