### PR TITLE
Corrected the SCTP PPID value

### DIFF
--- a/diam/network_sctp.go
+++ b/diam/network_sctp.go
@@ -27,7 +27,8 @@ const (
 
 	// DiameterPPID - SCTP Payload Protocol Identifier for Diameter
 	// see: https://tools.ietf.org/html/rfc4960#section-14.4 and https://tools.ietf.org/html/rfc6733#page-24
-	DiameterPPID uint32 = 46
+	// Value of PPID must be in network byte order (https://tools.ietf.org/html/rfc6458 Section 5.3.2)
+	DiameterPPID uint32 = 46 << 24
 )
 
 type sctpDialer struct {


### PR DESCRIPTION
Hello!
According with  https://tools.ietf.org/html/rfc6458 Section 5.3.2 PPID have to be translated to network byte order.

>sinfo_ppid: This value in sendmsg() is an unsigned integer that is
passed to the remote end in each user message. In recvmsg(), this
value is the same information that was passed by the upper layer
in the peer application. Please note that the SCTP stack performs
no byte order modification of this field. For example, if the
DATA chunk has to contain a given value in network byte order, the
SCTP user has to perform the htonl() computation.

Current value of PPID 46 encoded as 771751936
Thanks!