### PR TITLE
Update time.go

### DIFF
--- a/diam/datatype/time.go
+++ b/diam/datatype/time.go
@@ -14,14 +14,22 @@ import (
 type Time time.Time
 
 const rfc868offset = 2208988800 // Diff. between 1970 and 1900 in seconds.
+//UTC time is reckoned from 6h 28m 16s UTC on 7 February 2036 because overload happens
+const rfc2030offset = 2085978496 // 2085978496 comes from FFFFFFFF – 2208988800
 
 // DecodeTime decodes a Time data type from byte array.
 func DecodeTime(b []byte) (Type, error) {
-	if len(b) != 4 {
-		return &Time{}, nil
-	}
-	return Time(time.Unix(int64(binary.BigEndian.Uint32(b))-rfc868offset, 0)), nil
+        if len(b) != 4 {
+                return &Time{}, nil
+        }
+        if (b[0] >> 7) == 0 {
+                return Time(time.Unix(int64(binary.BigEndian.Uint32(b))+rfc2030offset, 0)), nil
+        } else {
+                return Time(time.Unix(int64(binary.BigEndian.Uint32(b))-rfc868offset, 0)), nil
+        }
+
 }
+
 
 // Serialize implements the Type interface.
 func (t Time) Serialize() []byte {


### PR DESCRIPTION
UTC time is reckoned from 6h 28m 16s UTC on 7 February 2036 because overload happens
Necessary for testing year 2038