### PR TITLE
Added embedded structs support to unmarshal/marshal

### DIFF
--- a/diam/reflect.go
+++ b/diam/reflect.go
@@ -86,7 +86,7 @@ func marshalStruct(m *Message, field reflect.Value) (error, []*AVP) {
 		f := base.Field(n)
 		bt := base.Type().Field(n)
 
-		if bt.Anonymous {
+		if bt.Anonymous && bt.Type.Kind() == reflect.Struct && len(bt.Tag) == 0 {
 			err, embeddedAvps := marshalStruct(m, f)
 			if err != nil {
 				return err, nil
@@ -379,7 +379,7 @@ func scanStruct(m *Message, field reflect.Value, avps []*AVP) error {
 		f := base.Field(n)
 		bt := base.Type().Field(n)
 
-		if bt.Anonymous {
+		if bt.Anonymous && bt.Type.Kind() == reflect.Struct && len(bt.Tag) == 0 {
 			if err := scanStruct(m, f, avps); err != nil {
 				return err
 			}

--- a/diam/reflect_test.go
+++ b/diam/reflect_test.go
@@ -363,6 +363,47 @@ func TestEmbeddedStruct(t *testing.T) {
 	if readBack.OriginHost != d.OriginHost {
 		t.Fatal("name does not match when mashal/unmarshalling")
 	}
+
+
+	// Test embedded non struct values
+	type CEREmb struct {
+		Common
+		net.IP `avp:"Host-IP-Address"`
+	}
+	var e CEREmb
+	if err := msg.Unmarshal(&e); err != nil {
+		t.Fatal(err)
+	}
+	if e.OriginHost != "test" {
+		t.Fatal("Embedded struct was not unmarshalled")
+	}
+	expectedIp := net.ParseIP("10.1.0.1")
+	if e.IP.String() != expectedIp.String() {
+		t.Fatalf("Embedded IP was not unmarshalled: %v != %v", e.IP, expectedIp)
+	}
+	newMsg = Message{
+		Header: &Header{
+			ApplicationID: 0,
+		},
+		dictionary: dict.Default,
+	}
+	err = newMsg.Marshal(&e)
+	if err != nil {
+		t.Fatal("Failed to marshal struct")
+	}
+	var readBackEmb CEREmb
+	if err = newMsg.Unmarshal(&readBackEmb); err != nil {
+		t.Fatal(err)
+	}
+	if readBackEmb.OriginHost != e.OriginHost {
+		t.Fatal("name does not match when mashal/unmarshalling")
+	}
+	if readBackEmb.IP.String() != expectedIp.String() {
+		t.Fatalf("Host IP does not match when mashal/unmarshalling: %v != %v", readBackEmb.IP, expectedIp)
+	}
+
+
+
 }
 
 func BenchmarkUnmarshal(b *testing.B) {

--- a/diam/reflect_test.go
+++ b/diam/reflect_test.go
@@ -323,6 +323,48 @@ func TestUnmarshalCER(t *testing.T) {
 	}
 }
 
+func TestEmbeddedStruct(t *testing.T) {
+	msg, err := ReadMessage(bytes.NewReader(testMessage), dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type Common struct {
+		OriginHost  string `avp:"Origin-Host"`
+		OriginRealm string `avp:"Origin-Realm"`
+	}
+	type CER struct {
+		Common
+		HostIP      net.IP `avp:"Host-IP-Address"`
+	}
+	var d CER
+	if err := msg.Unmarshal(&d); err != nil {
+		t.Fatal(err)
+	}
+	if d.OriginHost != "test" {
+		t.Fatal("Embedded struct was not unmarshalled")
+	}
+
+	newMsg := Message{
+		Header: &Header{
+			ApplicationID: 0,
+		},
+		dictionary: dict.Default,
+	}
+	err = newMsg.Marshal(&d)
+	if err != nil {
+		t.Fatal("Failed to marshal struct")
+	}
+
+
+	var readBack CER
+	if err = newMsg.Unmarshal(&readBack); err != nil {
+		t.Fatal(err)
+	}
+	if readBack.OriginHost != d.OriginHost {
+		t.Fatal("name does not match when mashal/unmarshalling")
+	}
+}
+
 func BenchmarkUnmarshal(b *testing.B) {
 	msg, err := ReadMessage(bytes.NewReader(testMessage), dict.Default)
 	if err != nil {


### PR DESCRIPTION
In our application we try to gather any shared data in common structs, which we then embed where they are used.
This way, we feel we get a easier overview of the data structures and less repetition. 
This small addition will add the support of embedded structs.