### PR TITLE
Handle complex hosts and skip loopback IP

### DIFF
--- a/diam/datatype/time.go
+++ b/diam/datatype/time.go
@@ -19,17 +19,16 @@ const rfc2030offset = 2085978496 // 2085978496 comes from FFFFFFFF – 220898880
 
 // DecodeTime decodes a Time data type from byte array.
 func DecodeTime(b []byte) (Type, error) {
-        if len(b) != 4 {
-                return &Time{}, nil
-        }
-        if (b[0] >> 7) == 0 {
-                return Time(time.Unix(int64(binary.BigEndian.Uint32(b))+rfc2030offset, 0)), nil
-        } else {
-                return Time(time.Unix(int64(binary.BigEndian.Uint32(b))-rfc868offset, 0)), nil
-        }
+	if len(b) != 4 {
+		return &Time{}, nil
+	}
+	if (b[0] >> 7) == 0 {
+		return Time(time.Unix(int64(binary.BigEndian.Uint32(b))+rfc2030offset, 0)), nil
+	} else {
+		return Time(time.Unix(int64(binary.BigEndian.Uint32(b))-rfc868offset, 0)), nil
+	}
 
 }
-
 
 // Serialize implements the Type interface.
 func (t Time) Serialize() []byte {

--- a/diam/reflect_test.go
+++ b/diam/reflect_test.go
@@ -334,7 +334,7 @@ func TestEmbeddedStruct(t *testing.T) {
 	}
 	type CER struct {
 		Common
-		HostIP      net.IP `avp:"Host-IP-Address"`
+		HostIP net.IP `avp:"Host-IP-Address"`
 	}
 	var d CER
 	if err := msg.Unmarshal(&d); err != nil {
@@ -355,7 +355,6 @@ func TestEmbeddedStruct(t *testing.T) {
 		t.Fatal("Failed to marshal struct")
 	}
 
-
 	var readBack CER
 	if err = newMsg.Unmarshal(&readBack); err != nil {
 		t.Fatal(err)
@@ -363,7 +362,6 @@ func TestEmbeddedStruct(t *testing.T) {
 	if readBack.OriginHost != d.OriginHost {
 		t.Fatal("name does not match when mashal/unmarshalling")
 	}
-
 
 	// Test embedded non struct values
 	type CEREmb struct {
@@ -401,8 +399,6 @@ func TestEmbeddedStruct(t *testing.T) {
 	if readBackEmb.IP.String() != expectedIp.String() {
 		t.Fatalf("Host IP does not match when mashal/unmarshalling: %v != %v", readBackEmb.IP, expectedIp)
 	}
-
-
 
 }
 

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -343,7 +343,7 @@ func getLocalAddresses(c diam.Conn) ([]datatype.Address, error) {
 	addresses := make([]datatype.Address, 0, len(hostIPs))
 	for _, ipStr := range hostIPs {
 		ip := net.ParseIP(ipStr)
-		if ip != nil {
+		if ip != nil && !ip.IsLoopback() {
 			addresses = append(addresses, datatype.Address(ip))
 		}
 	}

--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -320,12 +320,22 @@ func (cli *Client) makeDWR(osid uint32) *diam.Message {
 	return m
 }
 
+func getHostsWithoutPort(hosts string) (string, error) {
+	i := len(hosts) - 1
+	for ; i >= 0 && hosts[i] != ':'; i-- {
+		if hosts[i] < '0' || hosts[i] > '9' {
+			return "", fmt.Errorf("found non numerical character in port at position %d", i+1)
+		}
+	}
+	return hosts[:i], nil
+}
+
 func getLocalAddresses(c diam.Conn) ([]datatype.Address, error) {
 	var addrStr string
 	if c.LocalAddr() != nil {
 		addrStr = c.LocalAddr().String()
 	}
-	addr, _, err := net.SplitHostPort(addrStr)
+	addr, err := getHostsWithoutPort(addrStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse local ip %s [%q]: %s", addrStr, c.LocalAddr(), err)
 	}

--- a/diam/sm/client_test.go
+++ b/diam/sm/client_test.go
@@ -345,8 +345,8 @@ func TestClient_Conn_LocalAddresses_Loopback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse local addresses: %v", err)
 	}
-	if len(addrList) > 0 {
-		t.Fatal("Loopback address was not skipped")
+	if len(addrList) != 1 {
+		t.Fatal("The only available loopback address was skipped")
 	}
 }
 


### PR DESCRIPTION
The server I was testing on (Centos 7, with SCTP transport) threw an error when receiving its first CER:

```
diameter error on 10.0.0.2:55261: failed to parse local ip 127.0.0.1/[::1%lo]/10.0.0.3/[fe80::78ef:0efb:a57b:15b9%eth0]:3868 ["127.0.0.1/[::1%lo]/10.0.0.3/[fe80::78ef:0efb:a57b:15b9%eth0]:3868"]: address 127.0.0.1/[::1%lo]/10.0.0.3/[fe80::78ef:0efb:a57b:15b9%eth0]:3868: too many colons in address
```

The list of hosts `127.0.0.1/[::1%lo]/10.0.0.3/[fe80::78ef:0efb:a57b:15b9%eth0]:3868` returned by `conn.LocalAddr()` cannot be properly parsed by `net. SplitHostPort`.

On top of that, after fixing the parsing, my server was still sending its loopback IP as part of the CEA: `AVP: Host-IP-Address(257) l=14 f=-M- val=127.0.0.1`.

This PR aims to fix both those issues and contains test cases for both.