### PR TITLE
Added option to loosen message parsing to allow AVPs with empty/invalid payloads while defaulting to strict parsing

### DIFF
--- a/diam/avp.go
+++ b/diam/avp.go
@@ -14,6 +14,9 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 )
 
+// Used to signal that parsing should not stop.
+type DecodeError error
+
 // AVP is a Diameter attribute-value-pair.
 type AVP struct {
 	Code     uint32        // Code of this AVP
@@ -91,7 +94,7 @@ func (a *AVP) DecodeFromBytes(data []byte, application uint32, dictionary *dict.
 	}
 	a.Data, err = datatype.Decode(dictAVP.Data.Type, payload)
 	if err != nil {
-		return err
+		return DecodeError(fmt.Errorf("%s(%d): %v", dictAVP.Name, dictAVP.Code, err))
 	}
 	// Handle grouped AVPs.
 	if a.Data.Type() == datatype.GroupedType {
@@ -100,7 +103,7 @@ func (a *AVP) DecodeFromBytes(data []byte, application uint32, dictionary *dict.
 			application, dictionary,
 		)
 		if err != nil {
-			return err
+			return DecodeError(fmt.Errorf("%s(%d): Grouped{%v}", dictAVP.Name, dictAVP.Code, err))
 		}
 	}
 	return nil

--- a/diam/datatype/address.go
+++ b/diam/datatype/address.go
@@ -17,19 +17,19 @@ type Address []byte
 // DecodeAddress decodes an Address data type from byte array.
 func DecodeAddress(b []byte) (Type, error) {
 	if len(b) < 3 {
-		return nil, fmt.Errorf("Not enough data to make an Address from byte[%d] = %+v", len(b), b)
+		return Address{}, fmt.Errorf("Not enough data to make an Address from byte[%d] = %+v", len(b), b)
 	}
 	if binary.BigEndian.Uint16(b[:2]) == 0 || binary.BigEndian.Uint16(b[:2]) == 65535 {
-		return nil, errors.New("Invalid address type received")
+		return Address{}, errors.New("Invalid address type received")
 	}
 	switch binary.BigEndian.Uint16(b[:2]) {
 	case 0x01:
 		if len(b[2:]) != 4 {
-			return nil, errors.New("Invalid length for IPv4")
+			return Address{}, errors.New("Invalid length for IPv4")
 		}
 	case 0x02:
 		if len(b[2:]) != 16 {
-			return nil, errors.New("Invalid length for IPv6")
+			return Address{}, errors.New("Invalid length for IPv6")
 		}
 	default:
 		return Address(b), nil
@@ -92,5 +92,8 @@ func (addr Address) String() string {
 	if ip6 := net.IP(addr).To16(); ip6 != nil {
 		return fmt.Sprintf("Address{%s},Padding:%d", net.IP(addr), addr.Padding())
 	}
-	return fmt.Sprintf("Address{%#v}, Type{%#v} Padding:%d", addr[2:], addr[:2], addr.Padding())
+	if len(addr) == 0 {
+		return "Address{},Padding:0" // NOTE: To avoid panicking on addr[2:]
+	}
+	return fmt.Sprintf("Address{%#v},Type{%#v},Padding:%d", addr[2:], addr[:2], addr.Padding())
 }

--- a/diam/datatype/enum.go
+++ b/diam/datatype/enum.go
@@ -12,10 +12,7 @@ type Enumerated Integer32
 // DecodeEnumerated decodes an Enumerated data type from byte array.
 func DecodeEnumerated(b []byte) (Type, error) {
 	v, err := DecodeInteger32(b)
-	if err != nil {
-		return nil, err
-	}
-	return Enumerated(v.(Integer32)), nil
+	return Enumerated(v.(Integer32)), err
 }
 
 // Serialize implements the Type interface.

--- a/diam/dict/parser.go
+++ b/diam/dict/parser.go
@@ -40,6 +40,14 @@ type Parser struct {
 	command map[codeIdx]*Command  // Command index
 	mu      sync.Mutex            // Protects all maps
 	once    sync.Once
+
+	// Strict indicates whether an error should be returned when one  or more
+	// AVPs are invalid/empty and cannot be properly decoded.
+	//
+	// Defaults to true. When set to false, all decoding errors found during the
+	// parsing process will be stored in the Message's DecodeErr field which is
+	// accessible from a request handler.
+	Strict bool
 }
 
 type codeIdx struct {
@@ -62,6 +70,7 @@ type appIdTypeIdx struct {
 // NewParser allocates a new Parser optionally loading dictionary XML files.
 func NewParser(filename ...string) (*Parser, error) {
 	p := new(Parser)
+	p.Strict = true
 	var err error
 	for _, f := range filename {
 		if err = p.LoadFile(f); err != nil {

--- a/diam/group.go
+++ b/diam/group.go
@@ -7,6 +7,7 @@ package diam
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
@@ -25,15 +26,19 @@ type GroupedAVP struct {
 func DecodeGrouped(data datatype.Grouped, application uint32, dictionary *dict.Parser) (*GroupedAVP, error) {
 	g := &GroupedAVP{}
 	b := []byte(data)
+	var errs []string
 	for n := 0; n < len(b); {
 		avp, err := DecodeAVP(b[n:], application, dictionary)
 		if err != nil {
-			return nil, err
+			errs = append(errs, err.Error())
 		}
 		g.AVP = append(g.AVP, avp)
 		n += avp.Len()
 	}
 	// TODO: handle nested groups?
+	if len(errs) > 0 {
+		return g, fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
 	return g, nil
 }
 

--- a/diam/server.go
+++ b/diam/server.go
@@ -169,10 +169,7 @@ func (c *conn) readMessage() (m *Message, err error) {
 	} else {
 		m, err = ReadMessage(c.buf.Reader, c.dictionary())
 	}
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
+	return m, err
 }
 
 // Serve a new connection.


### PR DESCRIPTION
I am working with equipments that can occasionally send slightly invalid messages, containing empty AVPs (the length is valid, but the "data" is empty).

This change aims to address this issue by adding an optional parameter in dictionaries to set whether the parsing of incoming messages should be strict or not (it is strict by default).

### TODO

* [ ] There is a missing change needed for this PR to work with #146: the latter introduces a new function called `dict.NewParserFromLibrary` and it needs to be modified to set `p.Strict = true` just like `dict.NewParser` does.

### Example usage

```go
dictionary, err := dict.NewParserFromLibrary(
    library.Base,
    library.CreditControl,
    library.TgppRoRf,
)
if err != nil {
    panic(err)
}
dictionary.Strict = false // Does not return an error when one or more incoming AVPs are invalid or empty

// declare stateMachine

if err := diam.ListenAndServeNetwork("tcp", "127.0.0.1", stateMachine, dictionary); err != nil {
    panic(err)
}
```

### How to get the parsing error?

When `Parser.Strict` is set to `false`, the parsing error is accessible like so:

```go
func myHandler(conn diam.Conn, msg *diam.Message) {
    if msg.DecodeErr != nil {
        // some custom logic, like logging the error
    }
}
```

Example error (shows the AVP stack, down the actual error, and it contains all the invalid AVPs, not just the first one):

`Failed to decode one or more AVPs: {Service-Information(873): Grouped{SMS-Information(2000): Grouped{Recipient-SCCP-Address(2010): Not enough data to make an Address from byte[0] = []}}}`