### PR TITLE
Support graceful shutdown

### DIFF
--- a/diam/server.go
+++ b/diam/server.go
@@ -143,7 +143,7 @@ func (c *conn) notifyClientGone() {
 }
 
 // A ConnState represents the state of a client connection to a server.
-type ConnState int
+type ConnState int8
 
 const (
 	// StateNew represents a new connection that is expected to
@@ -178,7 +178,11 @@ var stateName = map[ConnState]string{
 }
 
 func (c ConnState) String() string {
-	return stateName[c]
+	name, ok := stateName[c]
+	if !ok {
+		return "UNDEFINED"
+	}
+	return name
 }
 
 // Create new connection from rwc.
@@ -209,7 +213,7 @@ func (c *conn) setState(state ConnState) {
 	case StateClosed:
 		srv.trackConn(c, false)
 	}
-	if state > 0xff || state < 0 {
+	if state > 0xf || state < 0 {
 		panic("internal error")
 	}
 	packedState := uint64(time.Now().Unix()<<8) | uint64(state)

--- a/diam/server.go
+++ b/diam/server.go
@@ -156,11 +156,6 @@ const (
 	// bytes of a request.
 	// After the request is handled, the state
 	// transitions to StateClosed, or StateIdle.
-	// For HTTP/2, StateActive fires on the transition from zero
-	// to one active request, and only transitions away once all
-	// active requests are complete. That means that ConnState
-	// cannot be used to do per-request work; ConnState only notes
-	// the overall state of the connection.
 	StateActive
 
 	// StateIdle represents a connection that has finished


### PR DESCRIPTION
This PR takes the minimal set of logic necessary to support graceful shutdown via a `Shutdown()` method from the [std net/http server](https://golang.org/src/net/http/server.go?s=85127:85181#L2689)

Note: this does **not** implement the diameter [peer disconnect](https://tools.ietf.org/html/rfc3588#section-5.4)