### PR TITLE
Bug. Parsing 'omitempty' from another tag value

### DIFF
--- a/diam/reflect.go
+++ b/diam/reflect.go
@@ -16,27 +16,16 @@ import (
 
 // parseAvpTag return the avp_name and omitempty option
 func parseAvpTag(tag reflect.StructTag) (string, bool) {
-	if tag == "" {
-		return "", false
+	var omitEmpty bool
+	name := tag.Get("avp")
+	if name == "" {
+		return "", omitEmpty
 	}
-	name := string(tag)
-	if strings.HasPrefix(name, "avp:\"") {
-		name = name[5 : len(name)-1]
-		omitEmpty := false
-		if strings.HasSuffix(name, ",omitempty") {
-			name = name[0 : len(name)-10]
-			omitEmpty = true
-		}
-		if strings.IndexByte(name, '"') == -1 {
-			return name, omitEmpty
-		}
+	if strings.HasSuffix(name, ",omitempty") {
+		name = name[0 : len(name)-10]
+		omitEmpty = true
 	}
-
-	name = tag.Get("avp")
-	if idx := strings.Index(name, ","); idx != -1 {
-		return name[:idx], false
-	}
-	return name, true
+	return name, omitEmpty
 }
 
 func isEmptyValue(v reflect.Value) bool {

--- a/diam/reflect_test.go
+++ b/diam/reflect_test.go
@@ -7,6 +7,7 @@ package diam
 import (
 	"bytes"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 

--- a/diam/reflect_test.go
+++ b/diam/reflect_test.go
@@ -424,3 +424,69 @@ func BenchmarkUnmarshal(b *testing.B) {
 		msg.Unmarshal(&cer)
 	}
 }
+
+func TestParseAvpTag(t *testing.T) {
+	testCases := []struct {
+		tag        string
+		expAvpName string
+		expOmit    bool
+	}{
+		{
+			tag:        "",
+			expAvpName: "",
+			expOmit:    false,
+		},
+		{
+			tag:        `json:"session"`,
+			expAvpName: "",
+			expOmit:    false,
+		},
+		{
+			tag:        `avp:"Session-Id"`,
+			expAvpName: "Session-Id",
+			expOmit:    false,
+		},
+		{
+			tag:        `avp:"Session-Id,omitempty"`,
+			expAvpName: "Session-Id",
+			expOmit:    true,
+		},
+		{
+			tag:        `avp:"Session-Id" json:"sessionId"`,
+			expAvpName: "Session-Id",
+			expOmit:    false,
+		},
+		{
+			tag:        `avp:"Session-Id,omitempty" json:"sessionId"`,
+			expAvpName: "Session-Id",
+			expOmit:    true,
+		},
+		{
+			tag:        `avp:"Session-Id" json:"sessionId,omitempty"`,
+			expAvpName: "Session-Id",
+			expOmit:    false,
+		},
+		{
+			tag:        `avp:"Session-Id,omitempty" json:"sessionId,omitempty"`,
+			expAvpName: "Session-Id",
+			expOmit:    true,
+		},
+	}
+	for _, test := range testCases {
+		avpName, omit := parseAvpTag(reflect.StructTag(test.tag))
+		if avpName != test.expAvpName {
+			t.Errorf("AVPName - got:%s\texpected:%s for tag `%s`\n",
+				avpName,
+				test.expAvpName,
+				test.tag,
+			)
+		}
+		if omit != test.expOmit {
+			t.Errorf("omitempty - got:%v\texpected:%v for tag `%s`\n",
+				omit,
+				test.expOmit,
+				test.tag,
+			)
+		}
+	}
+}


### PR DESCRIPTION
If struct has several tags, the function `parseAvpTag` will get 'omitempty' value from json tag

Function will return ("Session-Id",true) for reflect.StructTag(`avp:"Session-Id" json:"session,omitempty")