### PR TITLE
Added AMBR Extended bitrates for 5g and Makefile for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: docker_stop docker_start check_docker check_docker_compose run_docker_test docker_test gen_diam test
+
+gen_diam:
+	cd diam; ./autogen.sh
+
+test: gen_diam
+	go test ./...
+
+##################
+# docker endpoints
+##################
+check_docker: ; @which docker > /dev/null
+
+check_docker_compose: ; @which docker-compose > /dev/null
+
+docker_start:
+	@cd docker; docker-compose up -d;
+
+docker_stop:
+	@cd docker; docker-compose down
+
+run_docker_test:
+	@cd docker; docker-compose exec go-diameter bash -c  "cd go-diameter/ && go test ./..."
+
+docker_test: check_docker check_docker_compose gen_diam docker_start run_docker_test
+	$(info )
+	$(info --- run `make docker_stop` to stop the test container --- )

--- a/README.md
+++ b/README.md
@@ -82,3 +82,21 @@ parsing messages is much slower than writing them, for example. This is
 because in order to parse messages it makes numerous dictionary lookups
 for AVP types, to be able to decode them. Encoding messages require less
 lookups and is generally simpler, thus faster.
+
+## Contribute
+
+In case you want to add new AVPs, please add them to `diam/dict/testdata` xml
+files. Then regenerate the go models using `./autogen.sh` you will find at 
+`diam` folder. This will modify files at `diam/dict` to include your changes.
+
+Before submitting PR, please run `make test` to test your changes. Or do it 
+manually:
+
+```
+	go test ./...
+```
+
+You also have the option to run the test using a Linux VM through Docker (this
+is not mandatory). To do so, run `make test_docker`. Runing test on Linux  can 
+be useful in case you add `sctp` tests. Note you will need to install
+docker and docker-compose.

--- a/diam/avp/codes.go
+++ b/diam/avp/codes.go
@@ -206,6 +206,12 @@ const (
 	ExpirationDate                             = 1439
 	Expires                                    = 888
 	Exponent                                   = 429
+	ExtendedAPNAMBRDL                          = 2848
+	ExtendedAPNAMBRUL                          = 2849
+	ExtendedGBRDL                              = 2850
+	ExtendedGBRUL                              = 2851
+	ExtendedMaxRequestedBWDL                   = 554
+	ExtendedMaxRequestedBWUL                   = 555
 	ExternalClient                             = 1479
 	ExtPDPAddress                              = 1621
 	ExtPDPType                                 = 1620

--- a/diam/dict/default.go
+++ b/diam/dict/default.go
@@ -3094,6 +3094,14 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 			<data type="Unsigned32"/>
 		</avp>
 
+		<avp name="Extended-GBR-DL" code="2850" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-GBR-UL" code="2851" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
 		<avp name="IMS-Application-Reference-Identifier" code="2601" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="UTF8String"/>
 		</avp>
@@ -3392,6 +3400,14 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 		</avp>
 
 		<avp name="Max-Requested-Bandwidth-UL" code="516" must="V,M"	may="P" must-not="-" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-Max-Requested-BW-DL" code="554" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-Max-Requested-BW-UL" code="555" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
 			<data type="Unsigned32"/>
 		</avp>
 
@@ -4036,12 +4052,18 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
 				<rule avp="QoS-Class-Identifier" required="false" max="1"/>
 				<rule avp="Max-Requested-Bandwidth-UL" required="false" max="1"/>
 				<rule avp="Max-Requested-Bandwidth-DL" required="false" max="1"/>
+				<rule avp="Extended-Max-Requested-BW-UL" required="false" max="1"/>
+				<rule avp="Extended-Max-Requested-BW-DL" required="false" max="1"/>
 				<rule avp="Guaranteed-Bitrate-UL" required="false" max="1"/>
 				<rule avp="Guaranteed-Bitrate-DL" required="false" max="1"/>
+				<rule avp="Extended-GBR-UL" required="false" max="1"/>
+				<rule avp="Extended-GBR-DL" required="false" max="1"/>
 				<rule avp="Bearer-Identifier" required="false" max="1"/>
 				<rule avp="Allocation-Retention-Priority" required="false" max="1"/>
 				<rule avp="APN-Aggregate-Max-Bitrate-UL" required="false" max="1"/>
 				<rule avp="APN-Aggregate-Max-Bitrate-DL" required="false" max="1"/>
+				<rule avp="Extended-APN-AMBR-UL" required="false" max="1"/>
+				<rule avp="Extended-APN-AMBR-DL" required="false" max="1"/>
 				<rule avp="Conditional-APN-Aggregate-Max-Bitrate" required="false"/>
 				<rule avp="AVP" required="false"/>
 			</data>
@@ -4940,6 +4962,14 @@ var tgpprorfXML = `<?xml version="1.0" encoding="UTF-8"?>
       <data type="Unsigned32"/>
     </avp>
 
+    <avp name="Extended-APN-AMBR-DL" code="2848" must="V" must-not="M" may= "P" may-encrypt="Y" vendor-id="10415">
+      <data type="Unsigned32"/>
+    </avp>
+
+    <avp name="Extended-APN-AMBR-UL" code="2849" must="V" must-not="M" may="P" may-encrypt="Y" vendor-id="10415">
+      <data type="Unsigned32"/>
+    </avp>
+
 	</application>
 </diameter>`
 
@@ -5489,6 +5519,8 @@ var tgpps6aXML = `<?xml version="1.0" encoding="UTF-8"?>
             <data type="Grouped">
                 <rule avp="Max-Requested-Bandwidth-UL" required="true" max="1"/>
                 <rule avp="Max-Requested-Bandwidth-DL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-UL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-DL" required="true" max="1"/>
                 <rule avp="AVP" required="false"/>
             </data>
         </avp>
@@ -6337,6 +6369,8 @@ var tgppswxXML = `<?xml version="1.0" encoding="UTF-8"?>
             <data type="Grouped">
                 <rule avp="Max-Requested-Bandwidth-UL" required="true" max="1"/>
                 <rule avp="Max-Requested-Bandwidth-DL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-UL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-DL" required="true" max="1"/>
                 <rule avp="AVP" required="false"/>
             </data>
         </avp>
@@ -6351,10 +6385,19 @@ var tgppswxXML = `<?xml version="1.0" encoding="UTF-8"?>
             <data type="Unsigned32"/>
         </avp>
 
+		<avp name="Extended-Max-Requested-BW-DL" code="554" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-Max-Requested-BW-UL" code="555" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
         <avp name="TGPP-Charging-Characteristics" code="13" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             <!-- 3GPP TS 29.061 [21] -->
             <data type="UTF8String"/>
         </avp>
+
 
         <avp name="APN-OI-Replacement" code="1427" must="M,V" may-encrypt="N" vendor-id="10415">
             <!-- 3GPP TS 29.272 Section 7.3.32 -->

--- a/diam/dict/testdata/tgpp_ro_rf.xml
+++ b/diam/dict/testdata/tgpp_ro_rf.xml
@@ -634,6 +634,14 @@
 			<data type="Unsigned32"/>
 		</avp>
 
+		<avp name="Extended-GBR-DL" code="2850" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-GBR-UL" code="2851" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
 		<avp name="IMS-Application-Reference-Identifier" code="2601" must="V,M" may="P" must-not="-" may-encrypt="N" vendor-id="10415">
 			<data type="UTF8String"/>
 		</avp>
@@ -932,6 +940,14 @@
 		</avp>
 
 		<avp name="Max-Requested-Bandwidth-UL" code="516" must="V,M"	may="P" must-not="-" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-Max-Requested-BW-DL" code="554" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-Max-Requested-BW-UL" code="555" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
 			<data type="Unsigned32"/>
 		</avp>
 
@@ -1576,12 +1592,18 @@
 				<rule avp="QoS-Class-Identifier" required="false" max="1"/>
 				<rule avp="Max-Requested-Bandwidth-UL" required="false" max="1"/>
 				<rule avp="Max-Requested-Bandwidth-DL" required="false" max="1"/>
+				<rule avp="Extended-Max-Requested-BW-UL" required="false" max="1"/>
+				<rule avp="Extended-Max-Requested-BW-DL" required="false" max="1"/>
 				<rule avp="Guaranteed-Bitrate-UL" required="false" max="1"/>
 				<rule avp="Guaranteed-Bitrate-DL" required="false" max="1"/>
+				<rule avp="Extended-GBR-UL" required="false" max="1"/>
+				<rule avp="Extended-GBR-DL" required="false" max="1"/>
 				<rule avp="Bearer-Identifier" required="false" max="1"/>
 				<rule avp="Allocation-Retention-Priority" required="false" max="1"/>
 				<rule avp="APN-Aggregate-Max-Bitrate-UL" required="false" max="1"/>
 				<rule avp="APN-Aggregate-Max-Bitrate-DL" required="false" max="1"/>
+				<rule avp="Extended-APN-AMBR-UL" required="false" max="1"/>
+				<rule avp="Extended-APN-AMBR-DL" required="false" max="1"/>
 				<rule avp="Conditional-APN-Aggregate-Max-Bitrate" required="false"/>
 				<rule avp="AVP" required="false"/>
 			</data>
@@ -2477,6 +2499,14 @@
     </avp>
 
     <avp name="APN-Aggregate-Max-Bitrate-UL" code="1041" must="V" must-not="M" may-encrypt="Y" vendor-id="10415">
+      <data type="Unsigned32"/>
+    </avp>
+
+    <avp name="Extended-APN-AMBR-DL" code="2848" must="V" must-not="M" may= "P" may-encrypt="Y" vendor-id="10415">
+      <data type="Unsigned32"/>
+    </avp>
+
+    <avp name="Extended-APN-AMBR-UL" code="2849" must="V" must-not="M" may="P" may-encrypt="Y" vendor-id="10415">
       <data type="Unsigned32"/>
     </avp>
 

--- a/diam/dict/testdata/tgpp_s6a.xml
+++ b/diam/dict/testdata/tgpp_s6a.xml
@@ -544,6 +544,8 @@
             <data type="Grouped">
                 <rule avp="Max-Requested-Bandwidth-UL" required="true" max="1"/>
                 <rule avp="Max-Requested-Bandwidth-DL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-UL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-DL" required="true" max="1"/>
                 <rule avp="AVP" required="false"/>
             </data>
         </avp>

--- a/diam/dict/testdata/tgpp_swx.xml
+++ b/diam/dict/testdata/tgpp_swx.xml
@@ -342,6 +342,8 @@
             <data type="Grouped">
                 <rule avp="Max-Requested-Bandwidth-UL" required="true" max="1"/>
                 <rule avp="Max-Requested-Bandwidth-DL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-UL" required="true" max="1"/>
+                <rule avp="Extended-Max-Requested-BW-DL" required="true" max="1"/>
                 <rule avp="AVP" required="false"/>
             </data>
         </avp>
@@ -356,10 +358,19 @@
             <data type="Unsigned32"/>
         </avp>
 
+		<avp name="Extended-Max-Requested-BW-DL" code="554" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
+		<avp name="Extended-Max-Requested-BW-UL" code="555" must="V"	may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
+			<data type="Unsigned32"/>
+		</avp>
+
         <avp name="TGPP-Charging-Characteristics" code="13" must="V" may="P" must-not="M" may-encrypt="Y" vendor-id="10415">
             <!-- 3GPP TS 29.061 [21] -->
             <data type="UTF8String"/>
         </avp>
+
 
         <avp name="APN-OI-Replacement" code="1427" must="M,V" may-encrypt="N" vendor-id="10415">
             <!-- 3GPP TS 29.272 Section 7.3.32 -->


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

This PR includes:

- Addition of different AVPs to support Extended bit rates (coming from this PR at magma https://github.com/magma/magma/issues/5676)
- Fix a bug that was preventing build 
- Created Makefile to run the test (docker and docker-compose required)
- Added instructions to run test on main README

To execute the test just run `make test`
```
% make test
Docker Compose is now in the Docker CLI, try `docker compose up`

go-diameter is up-to-date
ok  	github.com/fiorix/go-diameter/v4/diam	(cached)
?   	github.com/fiorix/go-diameter/v4/diam/avp	[no test files]
ok  	github.com/fiorix/go-diameter/v4/diam/datatype	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/diamtest	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/dict	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/sm	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/sm/smparser	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/sm/smpeer	(cached)
?   	github.com/fiorix/go-diameter/v4/examples/bare	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/client/diameter_sy	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/diam_sctp_client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/grouped	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/protos	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/service	[no test files]
ok  	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/service/test	(cached)
?   	github.com/fiorix/go-diameter/v4/examples/s6a_server	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/server	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/snoop	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/wireshark-dict-tool	[no test files]

--- run `make docker_stop` to stop the test container ---
```