### PR TITLE
Ensure all AVP datatypes copy out of readBuffer

### DIFF
--- a/diam/datatype/address.go
+++ b/diam/datatype/address.go
@@ -32,9 +32,13 @@ func DecodeAddress(b []byte) (Type, error) {
 			return nil, errors.New("Invalid length for IPv6")
 		}
 	default:
-		return Address(b), nil
+		tmp := make([]byte, len(b))
+		copy(tmp, b)
+		return Address(tmp), nil
 	}
-	return Address(b[2:]), nil
+	tmp := make([]byte, len(b))
+	copy(tmp, b)
+	return Address(tmp[2:]), nil
 }
 
 // Serialize implements the Type interface.

--- a/diam/datatype/group.go
+++ b/diam/datatype/group.go
@@ -11,7 +11,9 @@ type Grouped []byte
 
 // DecodeGrouped decodes a Grouped data type from byte array.
 func DecodeGrouped(b []byte) (Type, error) {
-	return Grouped(b), nil
+	tmp := make([]byte, len(b))
+	copy(tmp, b)
+	return Grouped(tmp), nil
 }
 
 // Serialize implements the Type interface.

--- a/diam/datatype/ipv4.go
+++ b/diam/datatype/ipv4.go
@@ -17,7 +17,9 @@ func DecodeIPv4(b []byte) (Type, error) {
 	if len(b) != 4 {
 		return IPv4{0, 0, 0, 0}, nil
 	}
-	return IPv4(b), nil
+	tmp := make([]byte, len(b))
+	copy(tmp, b)
+	return IPv4(tmp), nil
 }
 
 // Serialize implements the Type interface.

--- a/diam/datatype/ipv6.go
+++ b/diam/datatype/ipv6.go
@@ -17,7 +17,9 @@ func DecodeIPv6(b []byte) (Type, error) {
 	if len(b) != net.IPv6len {
 		return IPv6(make(net.IP, net.IPv6len)), nil
 	}
-	return IPv6(b), nil
+	tmp := make([]byte, len(b))
+	copy(tmp, b)
+	return IPv6(tmp), nil
 }
 
 // Serialize implements the Type interface.

--- a/diam/datatype/unknown.go
+++ b/diam/datatype/unknown.go
@@ -11,7 +11,9 @@ type Unknown []byte
 
 // DecodeUnknown decodes an Unknown from byte array.
 func DecodeUnknown(b []byte) (Type, error) {
-	return Unknown(b), nil
+	tmp := make([]byte, len(b))
+	copy(tmp, b)
+	return Unknown(tmp), nil
 }
 
 // Serialize implements the Type interface.


### PR DESCRIPTION
Fixes: https://github.com/fiorix/go-diameter/issues/164