### PR TITLE
Fixed wrong type for VisitedPLMNID

### DIFF
--- a/diam/sm/s6a_client_server_test.go
+++ b/diam/sm/s6a_client_server_test.go
@@ -200,7 +200,7 @@ func testHandleAIR(results chan error, settings *Settings) diam.HandlerFunc {
 		OriginRealm             datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState        datatype.UTF8String       `avp:"Auth-Session-State"`
 		UserName                string                    `avp:"User-Name"`
-		VisitedPLMNID           datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID           datatype.OctetString      `avp:"Visited-PLMN-Id"`
 		RequestedEUTRANAuthInfo RequestedEUTRANAuthInfo   `avp:"Requested-EUTRAN-Authentication-Info"`
 	}
 	return func(c diam.Conn, m *diam.Message) {
@@ -300,7 +300,7 @@ func testHandleULR(results chan error, settings *Settings) diam.HandlerFunc {
 		OriginRealm      datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState datatype.Unsigned32       `avp:"Auth-Session-State"`
 		UserName         datatype.UTF8String       `avp:"User-Name"`
-		VisitedPLMNID    datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID    datatype.OctetString      `avp:"Visited-PLMN-Id"`
 		RATType          datatype.Unsigned32       `avp:"RAT-Type"`
 		ULRFlags         datatype.Unsigned32       `avp:"ULR-Flags"`
 	}

--- a/examples/s6a_proxy/service/test/test_s6a_server.go
+++ b/examples/s6a_proxy/service/test/test_s6a_server.go
@@ -85,7 +85,7 @@ func testHandleAIR(settings *sm.Settings) diam.HandlerFunc {
 		OriginRealm             datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState        datatype.UTF8String       `avp:"Auth-Session-State"`
 		UserName                string                    `avp:"User-Name"`
-		VisitedPLMNID           datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID           datatype.OctetString      `avp:"Visited-PLMN-Id"`
 		RequestedEUTRANAuthInfo RequestedEUTRANAuthInfo   `avp:"Requested-EUTRAN-Authentication-Info"`
 	}
 	return func(c diam.Conn, m *diam.Message) {
@@ -147,7 +147,7 @@ func testHandleULR(settings *sm.Settings) diam.HandlerFunc {
 		OriginRealm      datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState datatype.Unsigned32       `avp:"Auth-Session-State"`
 		UserName         datatype.UTF8String       `avp:"User-Name"`
-		VisitedPLMNID    datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID    datatype.OctetString      `avp:"Visited-PLMN-Id"`
 		RATType          datatype.Unsigned32       `avp:"RAT-Type"`
 		ULRFlags         datatype.Unsigned32       `avp:"ULR-Flags"`
 	}

--- a/examples/s6a_server/server.go
+++ b/examples/s6a_server/server.go
@@ -104,7 +104,7 @@ func handleAIR(settings sm.Settings) diam.HandlerFunc {
 		OriginRealm             datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState        datatype.UTF8String       `avp:"Auth-Session-State"`
 		UserName                string                    `avp:"User-Name"`
-		VisitedPLMNID           datatype.OctetString       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID           datatype.OctetString      `avp:"Visited-PLMN-Id"`
 		RequestedEUTRANAuthInfo RequestedEUTRANAuthInfo   `avp:"Requested-EUTRAN-Authentication-Info"`
 	}
 	return func(c diam.Conn, m *diam.Message) {
@@ -195,7 +195,7 @@ func handleULR(settings sm.Settings) diam.HandlerFunc {
 		OriginRealm      datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState datatype.Unsigned32       `avp:"Auth-Session-State"`
 		UserName         datatype.UTF8String       `avp:"User-Name"`
-		VisitedPLMNID    datatype.OctetString       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID    datatype.OctetString      `avp:"Visited-PLMN-Id"`
 		RATType          datatype.Unsigned32       `avp:"RAT-Type"`
 		ULRFlags         datatype.Unsigned32       `avp:"ULR-Flags"`
 	}

--- a/examples/s6a_server/server.go
+++ b/examples/s6a_server/server.go
@@ -104,7 +104,7 @@ func handleAIR(settings sm.Settings) diam.HandlerFunc {
 		OriginRealm             datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState        datatype.UTF8String       `avp:"Auth-Session-State"`
 		UserName                string                    `avp:"User-Name"`
-		VisitedPLMNID           datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID           datatype.OctetString       `avp:"Visited-PLMN-Id"`
 		RequestedEUTRANAuthInfo RequestedEUTRANAuthInfo   `avp:"Requested-EUTRAN-Authentication-Info"`
 	}
 	return func(c diam.Conn, m *diam.Message) {
@@ -195,7 +195,7 @@ func handleULR(settings sm.Settings) diam.HandlerFunc {
 		OriginRealm      datatype.DiameterIdentity `avp:"Origin-Realm"`
 		AuthSessionState datatype.Unsigned32       `avp:"Auth-Session-State"`
 		UserName         datatype.UTF8String       `avp:"User-Name"`
-		VisitedPLMNID    datatype.Unsigned32       `avp:"Visited-PLMN-Id"`
+		VisitedPLMNID    datatype.OctetString       `avp:"Visited-PLMN-Id"`
 		RATType          datatype.Unsigned32       `avp:"RAT-Type"`
 		ULRFlags         datatype.Unsigned32       `avp:"ULR-Flags"`
 	}


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

VisitedPLMNID is set as `Unsigned` type but it is type `OctetString`. 

We found out this because our HSS implementation was always returning `VisitedPLMNID` as 0.

test passed
```

╰─ make run_docker_test
ok  	github.com/fiorix/go-diameter/v4/diam	(cached)
?   	github.com/fiorix/go-diameter/v4/diam/avp	[no test files]
ok  	github.com/fiorix/go-diameter/v4/diam/datatype	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/diamtest	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/dict	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/sm	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/sm/smparser	(cached)
ok  	github.com/fiorix/go-diameter/v4/diam/sm/smpeer	(cached)
?   	github.com/fiorix/go-diameter/v4/examples/bare	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/client/diameter_sy	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/diam_sctp_client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/grouped	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_client	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/protos	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/service	[no test files]
ok  	github.com/fiorix/go-diameter/v4/examples/s6a_proxy/service/test	(cached)
?   	github.com/fiorix/go-diameter/v4/examples/s6a_server	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/server	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/snoop	[no test files]
?   	github.com/fiorix/go-diameter/v4/examples/wireshark-dict-tool	[no test files]
```
