### PR TITLE
Fixed incorrect SCTPConn type in diam_sctp_client (#170)

### DIFF
--- a/examples/diam_sctp_client/main.go
+++ b/examples/diam_sctp_client/main.go
@@ -55,7 +55,7 @@ func main() {
 		log.Fatal(err)
 		return
 	}
-	sctpConn := cli.Connection().(*sctp.SCTPConn)
+	sctpConn := cli.Connection().(*diam.SCTPConn)
 	sctpLAdds, err = sctpConn.SCTPLocalAddr(0)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
The example SCTP client was crashing on connection:
> panic: interface conversion: net.Conn is *diam.SCTPConn, not *sctp.SCTPConn