### PR TITLE
Unknown AVP Handling

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@
 DanB <danb@cgrates.org>
 David Wilkie <dwilkie@gmail.com>
 Seyi Ogunyemi <micrypt@users.noreply.github.com>
+Talha <raotalha302.rt@gmail.com>
 Tapio <fitase@emblacom.com>
 jaroszan <jaroslaw.szangin@gmail.com>
 mspronk <martijn@orangemountain.ca>

--- a/diam/dict/util.go
+++ b/diam/dict/util.go
@@ -124,7 +124,12 @@ retry:
 		goto retry
 	} else {
 		if codeU32, isUint32 := code.(uint32); isUint32 {
-			return MakeUnknownAVP(origAppID, codeU32, vendorID), err
+			avp, err = p.FindAVP(origAppID, codeU32)
+			if err != nil {
+				return MakeUnknownAVP(origAppID, codeU32, vendorID), err
+			}
+
+			return avp, nil
 		}
 	}
 


### PR DESCRIPTION
Before assinging Unknown type to a AVP, we recheck it in the dictionary. This helps identifying the type of AVP because many time we have the avp but we still set it to unknown type.