### PR TITLE
creating hsNotifyc as a buffered channel

### DIFF
--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -96,7 +96,7 @@ func New(settings *Settings) *StateMachine {
 	sm := &StateMachine{
 		cfg:           settings,
 		mux:           diam.NewServeMux(),
-		hsNotifyc:     make(chan diam.Conn),
+		hsNotifyc:     make(chan diam.Conn, 10),
 		supportedApps: PrepareSupportedApps(dict.Default),
 	}
 	sm.mux.Handle("CER", handleCER(sm))


### PR DESCRIPTION
If two clients connect at the same time, an HS notification may be lost because writing to the channel is non-blocking and the channel is not buffered.