### PR TITLE
Remove vendor id for MIP-Home-Agent-Address, MIP-Home-Agent-Host and …

### DIFF
--- a/diam/dict/testdata/tgpp_s6a.xml
+++ b/diam/dict/testdata/tgpp_s6a.xml
@@ -1058,12 +1058,13 @@
             </data>
         </avp>
 
-        <avp name="MIP-Home-Agent-Address" code="334" must="M" must-not="V" vendor-id="10415">
+        <!-- RFC 4004 -->
+        <avp name="MIP-Home-Agent-Address" code="334" must="M" must-not="V">
             <data type="Address"/>
         </avp>
 
         <!-- RFC 4004 -->
-        <avp name="MIP-Home-Agent-Host" code="348" must="M" may="P" must-not="V" may-encrypt="Y" vendor-id="10415">
+        <avp name="MIP-Home-Agent-Host" code="348" must="M" may="P" must-not="V" may-encrypt="Y">
             <data type="Grouped">
                 <rule avp="Destination-Realm" required="true" max="1"/>
                 <rule avp="Destination-Host" required="true" max="1"/>
@@ -1089,7 +1090,8 @@
             <data type="OctetString"/>
         </avp>
 
-        <avp name="MIP6-Home-Link-Prefix" code="125" vendor-id="10415">
+        <!-- RFC 5447 Diameter Mobile IPv6: Support for Network Access Server to Diameter Server Interaction -->
+        <avp name="MIP6-Home-Link-Prefix" code="125">
             <data type="OctetString"/>
         </avp>
 

--- a/diam/dict/testdata/tgpp_swx.xml
+++ b/diam/dict/testdata/tgpp_swx.xml
@@ -219,7 +219,7 @@
         </avp>
 
         <!-- RFC 5447 Diameter Mobile IPv6: Support for Network Access Server to Diameter Server Interaction -->
-        <avp name="MIP6-Agent-Info" code="486" must="M" may="P" must-not="V" may-encrypt="Y" vendor-id="10415">
+        <avp name="MIP6-Agent-Info" code="486" must="M" may="P" must-not="V" may-encrypt="Y">
             <data type="Grouped">
                 <rule avp="MIP-Home-Agent-Address" required="false" max="2"/>
                 <rule avp="MIP-Home-Agent-Host" required="false" max="1"/>


### PR DESCRIPTION
…MIP6-Home-Link-Prefix (cause they are from RFC 4004, 4004 and 5447 respectively and are not have a vendor id in specification)