### PR TITLE
fix: fixes DiameterPPID with the latest sctp package

### DIFF
--- a/diam/network_sctp.go
+++ b/diam/network_sctp.go
@@ -27,8 +27,8 @@ const (
 
 	// DiameterPPID - SCTP Payload Protocol Identifier for Diameter
 	// see: https://tools.ietf.org/html/rfc4960#section-14.4 and https://tools.ietf.org/html/rfc6733#page-24
-	// Value of PPID must be in network byte order (https://tools.ietf.org/html/rfc6458 Section 5.3.2)
-	DiameterPPID uint32 = 46 << 24
+	// Value of PPID in network byte order is implicitly handed in the SCTP package using htonl() (https://tools.ietf.org/html/rfc6458 Section 5.3.2)
+	DiameterPPID uint32 = 46
 )
 
 type sctpDialer struct {
@@ -343,10 +343,10 @@ func (msc *SCTPConn) Read(b []byte) (n int, err error) {
 
 // Write writes data to the association while maintaining stream continuity.
 // The write stream will be selected in the following order:
-//   1) If current write stream is set (is not InvalidStreamID), it'll be used for writing.
-//   2) If current read stream is set, it'll be used for writing.
-//   3) If neither current write nor current read streams are set, write will use default
-//      protocol stream (0 for the current SCTP implementation).
+//  1. If current write stream is set (is not InvalidStreamID), it'll be used for writing.
+//  2. If current read stream is set, it'll be used for writing.
+//  3. If neither current write nor current read streams are set, write will use default
+//     protocol stream (0 for the current SCTP implementation).
 func (msc *SCTPConn) Write(b []byte) (int, error) {
 	msc.wmu.RLock() // block changes to msc.writerStream during write
 	defer msc.wmu.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
-	github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2
+	github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2
 	google.golang.org/grpc v1.24.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2 h1:i2fYnDurfLlJH8AyyMOnkLHnHeP8Ff/DDpuZA/D3bPo=
-github.com/ishidawataru/sctp v0.0.0-20230406120618-7ff4192f6ff2/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
+github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2 h1:36qep4gxKs+JgeHGWeQ040RyZdt9kQlLglL1rFVn/oQ=
+github.com/ishidawataru/sctp v0.0.0-20251114114122-19ddcbc6aae2/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
This PR updates to latest sctp package. It also uses normal PPID as the ordering is now implicitly handled in the sctp package.