### PR TITLE
Fix Unmarshal ignoring VendorId for AVPs with same code (#169)

### DIFF
--- a/diam/reflect.go
+++ b/diam/reflect.go
@@ -388,7 +388,7 @@ func scanStruct(m *Message, field reflect.Value, avps []*AVP) error {
 		}
 		// Lookup the AVP name (tag) in the dictionary.
 		// The dictionary AVP has the code.
-		d, err := m.Dictionary().FindAVP(m.Header.ApplicationID, avpname) // Relies on the fact that in the same app will not be AVPs with same code but different vendorId
+		d, err := m.Dictionary().FindAVP(m.Header.ApplicationID, avpname)
 		if err != nil {
 			return err
 		}

--- a/diam/reflect.go
+++ b/diam/reflect.go
@@ -349,12 +349,18 @@ func (m *Message) Unmarshal(dst interface{}) error {
 	return scanStruct(m, v, m.AVP)
 }
 
-// newIndex returns a map of AVPs indexed by their code.
-// TODO: make this part of the Message.
-func newIndex(avps []*AVP) map[uint32][]*AVP {
-	idx := make(map[uint32][]*AVP, len(avps))
+// avpKey identifies an AVP by both Code and VendorID.
+type avpKey struct {
+	Code     uint32
+	VendorID uint32
+}
+
+// newIndex returns a map of AVPs indexed by their {Code, VendorID}.
+func newIndex(avps []*AVP) map[avpKey][]*AVP {
+	idx := make(map[avpKey][]*AVP, len(avps))
 	for _, a := range avps {
-		idx[a.Code] = append(idx[a.Code], a)
+		key := avpKey{a.Code, a.VendorID}
+		idx[key] = append(idx[key], a)
 	}
 	return idx
 }
@@ -387,7 +393,7 @@ func scanStruct(m *Message, field reflect.Value, avps []*AVP) error {
 			return err
 		}
 		// See if this AVP exist in the message.
-		avps, exists := idx[d.Code]
+		avps, exists := idx[avpKey{d.Code, d.VendorID}]
 		if !exists {
 			continue
 		}

--- a/diam/unmarshal_vendorid_test.go
+++ b/diam/unmarshal_vendorid_test.go
@@ -1,6 +1,7 @@
 package diam
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/fiorix/go-diameter/v4/diam/avp"
@@ -8,80 +9,48 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/dict"
 )
 
-// TestUnmarshalVendorId reproduces #169: when two AVPs share the same code
-// but have different VendorIds, Unmarshal puts the wrong data into the struct.
+// TestUnmarshalVendorId is a regression test for #169.
+//
+// newIndex used to key AVPs by Code only, so AVPs with the same code but
+// different VendorIds ended up in the same bucket. scanStruct then picked
+// the first match regardless of VendorId, corrupting the destination
+// struct. After the fix, {Code, VendorID} is the index key and Unmarshal
+// distinguishes the two AVPs correctly. This test drives the public
+// Unmarshal API so it catches any regression in scanStruct's use of the
+// index, not just in newIndex.
 func TestUnmarshalVendorId(t *testing.T) {
-	// User-Password (code=2, vendor=0) and 3GPP-Charging-Id (code=2, vendor=10415)
-	// both have AVP code 2. Unmarshal should distinguish them by VendorId.
-
-	// Load a dictionary that has both AVPs with code=2 but different vendors.
-	// The base dict already has Inband-Security-Id (code=299) and the 3GPP dict
-	// has several vendor-specific AVPs. Let's use a simpler approach:
-	// build a message with two AVPs that share code but differ by vendor.
-
-	m := NewRequest(272, 4, dict.Default) // CCR
-	// AVP code 2, vendor 0 (base protocol doesn't define code=2, so use raw)
-	m.AddAVP(NewAVP(2, avp.Mbit, 0, datatype.OctetString("base-password")))
-	// AVP code 2, vendor 10415 (3GPP-Charging-Id in Ro/Rf dict)
-	m.AddAVP(NewAVP(2, avp.Mbit|avp.Vbit, 10415, datatype.Unsigned32(12345)))
-
-	type testStruct struct {
-		BaseAVP    datatype.OctetString  `avp:"User-Password"`
-		ChargingId datatype.Unsigned32   `avp:"3GPP-Charging-Id"`
+	// Two AVPs sharing code 777 but differing by VendorID.
+	const dictXML = `<?xml version="1.0" encoding="UTF-8"?>
+<diameter>
+  <application id="4">
+    <avp name="Example-Base" code="777" must="M" may="-" must-not="V" may-encrypt="Y">
+      <data type="OctetString" />
+    </avp>
+    <avp name="Example-Vendor" code="777" must="M,V" may="-" must-not="-" may-encrypt="Y" vendor-id="10415">
+      <data type="Unsigned32" />
+    </avp>
+  </application>
+</diameter>`
+	if err := dict.Default.Load(bytes.NewReader([]byte(dictXML))); err != nil {
+		t.Fatalf("load dict: %v", err)
 	}
 
-	// This will fail if the dictionary doesn't have both names.
-	// Let's test with raw AVP access first to prove the index bug.
-	idx := newIndex(m.AVP)
-
-	// Both AVPs have code=2 — with the fix they should be in separate buckets
-	bucket0, exists0 := idx[avpKey{2, 0}]
-	bucket3gpp, exists3gpp := idx[avpKey{2, 10415}]
-
-	if !exists0 {
-		t.Fatal("AVP code=2 vendor=0 not found in index")
-	}
-	if !exists3gpp {
-		t.Fatal("AVP code=2 vendor=10415 not found in index")
-	}
-	if len(bucket0) != 1 || len(bucket3gpp) != 1 {
-		t.Fatalf("expected 1 AVP per bucket, got %d and %d", len(bucket0), len(bucket3gpp))
-	}
-
-	t.Logf("AVP vendor=0: code=%d data=%v", bucket0[0].Code, bucket0[0].Data)
-	t.Logf("AVP vendor=10415: code=%d data=%v", bucket3gpp[0].Code, bucket3gpp[0].Data)
-
-	if bucket0[0].VendorID != 0 {
-		t.Error("wrong AVP in vendor=0 bucket")
-	}
-	if bucket3gpp[0].VendorID != 10415 {
-		t.Error("wrong AVP in vendor=10415 bucket")
-	}
-}
-
-// TestUnmarshalVendorIdFix verifies that after the fix, AVPs with the same
-// code but different VendorIds are correctly distinguished during Unmarshal.
-func TestUnmarshalVendorIdFix(t *testing.T) {
 	m := NewRequest(272, 4, dict.Default)
-	m.AddAVP(NewAVP(2, avp.Mbit, 0, datatype.OctetString("base-data")))
-	m.AddAVP(NewAVP(2, avp.Mbit|avp.Vbit, 10415, datatype.Unsigned32(99999)))
+	m.AddAVP(NewAVP(777, avp.Mbit, 0, datatype.OctetString("base-data")))
+	m.AddAVP(NewAVP(777, avp.Mbit|avp.Vbit, 10415, datatype.Unsigned32(12345)))
 
-	idx := newIndex(m.AVP)
+	var dst struct {
+		Base   datatype.OctetString `avp:"Example-Base"`
+		Vendor datatype.Unsigned32  `avp:"Example-Vendor"`
+	}
+	if err := m.Unmarshal(&dst); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
 
-	// After fix: AVPs with different VendorIds should be in separate buckets
-	v0, ok0 := idx[avpKey{2, 0}]
-	v3gpp, ok3gpp := idx[avpKey{2, 10415}]
-
-	if !ok0 || len(v0) != 1 {
-		t.Fatal("vendor=0 AVP not correctly indexed")
+	if got, want := string(dst.Base), "base-data"; got != want {
+		t.Errorf("Base: got %q, want %q (wrong AVP routed to Base field)", got, want)
 	}
-	if !ok3gpp || len(v3gpp) != 1 {
-		t.Fatal("vendor=10415 AVP not correctly indexed")
-	}
-	if string(v0[0].Data.(datatype.OctetString)) != "base-data" {
-		t.Errorf("vendor=0 AVP has wrong data: %v", v0[0].Data)
-	}
-	if uint32(v3gpp[0].Data.(datatype.Unsigned32)) != 99999 {
-		t.Errorf("vendor=10415 AVP has wrong data: %v", v3gpp[0].Data)
+	if got, want := uint32(dst.Vendor), uint32(12345); got != want {
+		t.Errorf("Vendor: got %d, want %d (wrong AVP routed to Vendor field)", got, want)
 	}
 }

--- a/diam/unmarshal_vendorid_test.go
+++ b/diam/unmarshal_vendorid_test.go
@@ -1,0 +1,87 @@
+package diam
+
+import (
+	"testing"
+
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+)
+
+// TestUnmarshalVendorId reproduces #169: when two AVPs share the same code
+// but have different VendorIds, Unmarshal puts the wrong data into the struct.
+func TestUnmarshalVendorId(t *testing.T) {
+	// User-Password (code=2, vendor=0) and 3GPP-Charging-Id (code=2, vendor=10415)
+	// both have AVP code 2. Unmarshal should distinguish them by VendorId.
+
+	// Load a dictionary that has both AVPs with code=2 but different vendors.
+	// The base dict already has Inband-Security-Id (code=299) and the 3GPP dict
+	// has several vendor-specific AVPs. Let's use a simpler approach:
+	// build a message with two AVPs that share code but differ by vendor.
+
+	m := NewRequest(272, 4, dict.Default) // CCR
+	// AVP code 2, vendor 0 (base protocol doesn't define code=2, so use raw)
+	m.AddAVP(NewAVP(2, avp.Mbit, 0, datatype.OctetString("base-password")))
+	// AVP code 2, vendor 10415 (3GPP-Charging-Id in Ro/Rf dict)
+	m.AddAVP(NewAVP(2, avp.Mbit|avp.Vbit, 10415, datatype.Unsigned32(12345)))
+
+	type testStruct struct {
+		BaseAVP    datatype.OctetString  `avp:"User-Password"`
+		ChargingId datatype.Unsigned32   `avp:"3GPP-Charging-Id"`
+	}
+
+	// This will fail if the dictionary doesn't have both names.
+	// Let's test with raw AVP access first to prove the index bug.
+	idx := newIndex(m.AVP)
+
+	// Both AVPs have code=2 — with the fix they should be in separate buckets
+	bucket0, exists0 := idx[avpKey{2, 0}]
+	bucket3gpp, exists3gpp := idx[avpKey{2, 10415}]
+
+	if !exists0 {
+		t.Fatal("AVP code=2 vendor=0 not found in index")
+	}
+	if !exists3gpp {
+		t.Fatal("AVP code=2 vendor=10415 not found in index")
+	}
+	if len(bucket0) != 1 || len(bucket3gpp) != 1 {
+		t.Fatalf("expected 1 AVP per bucket, got %d and %d", len(bucket0), len(bucket3gpp))
+	}
+
+	t.Logf("AVP vendor=0: code=%d data=%v", bucket0[0].Code, bucket0[0].Data)
+	t.Logf("AVP vendor=10415: code=%d data=%v", bucket3gpp[0].Code, bucket3gpp[0].Data)
+
+	if bucket0[0].VendorID != 0 {
+		t.Error("wrong AVP in vendor=0 bucket")
+	}
+	if bucket3gpp[0].VendorID != 10415 {
+		t.Error("wrong AVP in vendor=10415 bucket")
+	}
+}
+
+// TestUnmarshalVendorIdFix verifies that after the fix, AVPs with the same
+// code but different VendorIds are correctly distinguished during Unmarshal.
+func TestUnmarshalVendorIdFix(t *testing.T) {
+	m := NewRequest(272, 4, dict.Default)
+	m.AddAVP(NewAVP(2, avp.Mbit, 0, datatype.OctetString("base-data")))
+	m.AddAVP(NewAVP(2, avp.Mbit|avp.Vbit, 10415, datatype.Unsigned32(99999)))
+
+	idx := newIndex(m.AVP)
+
+	// After fix: AVPs with different VendorIds should be in separate buckets
+	v0, ok0 := idx[avpKey{2, 0}]
+	v3gpp, ok3gpp := idx[avpKey{2, 10415}]
+
+	if !ok0 || len(v0) != 1 {
+		t.Fatal("vendor=0 AVP not correctly indexed")
+	}
+	if !ok3gpp || len(v3gpp) != 1 {
+		t.Fatal("vendor=10415 AVP not correctly indexed")
+	}
+	if string(v0[0].Data.(datatype.OctetString)) != "base-data" {
+		t.Errorf("vendor=0 AVP has wrong data: %v", v0[0].Data)
+	}
+	if uint32(v3gpp[0].Data.(datatype.Unsigned32)) != 99999 {
+		t.Errorf("vendor=10415 AVP has wrong data: %v", v3gpp[0].Data)
+	}
+}


### PR DESCRIPTION
Fixes #169

## Problem

`newIndex()` in `reflect.go` keys AVPs by `Code` only. When two AVPs share the same code but have different VendorIds (e.g. User-Password code=2 vendor=0 and 3GPP-Charging-Id code=2 vendor=10415), they end up in the same index bucket. `scanStruct()` then picks `avps[0]` regardless of VendorId, causing the wrong data to be assigned.

## Fix

Key the index by `{Code, VendorID}` instead of just `Code`. The lookup in `scanStruct` now uses both the dictionary AVP code and vendor ID.

## Testing

New test `TestUnmarshalVendorId` confirms AVPs with same code but different VendorIds are correctly separated. All existing tests pass.