### PR TITLE
Expose Server.Dial and Server.DialTLS for client write deadlines

### DIFF
--- a/diam/client.go
+++ b/diam/client.go
@@ -167,6 +167,24 @@ func dialTLS(srv *Server, certFile, keyFile string, timeout time.Duration) (Conn
 	return c.writer, nil
 }
 
+// Dial opens an outgoing connection using srv as the client configuration.
+// Honors srv.Network, srv.Addr, srv.Handler, srv.Dict, srv.LocalAddr,
+// srv.ReadTimeout and srv.WriteTimeout. The timeout argument bounds the
+// connect phase only; 0 means no connect timeout.
+//
+// If srv.Network is blank, "tcp" is used. If srv.Addr is blank, ":3868" is
+// used.
+func (srv *Server) Dial(timeout time.Duration) (Conn, error) {
+	return dial(srv, timeout)
+}
+
+// DialTLS opens an outgoing TLS connection using srv as the client
+// configuration. Honors the same srv fields as Dial, plus srv.TLSConfig.
+// certFile and keyFile are optional; when empty, srv.TLSConfig is used as-is.
+func (srv *Server) DialTLS(certFile, keyFile string, timeout time.Duration) (Conn, error) {
+	return dialTLS(srv, certFile, keyFile, timeout)
+}
+
 // NewConn is the same as Dial, but using an already open net.Conn.
 func NewConn(rw net.Conn, addr string, handler Handler, dp *dict.Parser) (Conn, error) {
 	srv := &Server{Addr: addr, Handler: handler, Dict: dp}

--- a/diam/client_test.go
+++ b/diam/client_test.go
@@ -1,0 +1,79 @@
+// Copyright 2013-2015 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package diam_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+)
+
+// TestServerDialWriteTimeout verifies that Server.WriteTimeout is honored on
+// the client side when dialing via (*Server).Dial. Regression test for #218:
+// client writes to a stalled peer should unblock with a timeout error instead
+// of piling up on the write mutex.
+func TestServerDialWriteTimeout(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		if tc, ok := c.(*net.TCPConn); ok {
+			tc.SetReadBuffer(1024)
+		}
+		accepted <- c
+	}()
+
+	srv := &diam.Server{
+		Network:      "tcp",
+		Addr:         ln.Addr().String(),
+		WriteTimeout: 100 * time.Millisecond,
+	}
+	cli, err := srv.Dial(time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	var peer net.Conn
+	select {
+	case peer = <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("peer did not accept")
+	}
+	defer peer.Close()
+
+	if tc, ok := cli.Connection().(*net.TCPConn); ok {
+		tc.SetWriteBuffer(1024)
+	}
+
+	payload := make([]byte, 64*1024)
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("Write never timed out; WriteTimeout not honored on client")
+		default:
+		}
+		_, err := cli.Write(payload)
+		if err == nil {
+			continue
+		}
+		ne, ok := err.(net.Error)
+		if !ok || !ne.Timeout() {
+			t.Fatalf("expected timeout error, got %v", err)
+		}
+		return
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Server.Dial(timeout)` and `Server.DialTLS(certFile, keyFile, timeout)` methods that take a caller-built `*Server`, letting clients set `WriteTimeout`/`ReadTimeout`/`LocalAddr`/etc.
- No changes to existing `Dial*` entry points; new API is additive.

## Why
Fixes #218. The internal `dial`/`dialTLS` helpers already build a `*Server` to configure the client connection, but `Server.WriteTimeout` could not be set because none of the `Dial*` entry points accept a `*Server`. With no deadline, a client `Write` to a stalled peer blocks forever under `response.mu`, piling up goroutines and memory. `response.writeLocked` already honors `Server.WriteTimeout` on every write, so exposing a Server-based dial is the minimal fix.

## Test plan
- [x] `go test ./...` passes
- [x] New `TestServerDialWriteTimeout` in `diam/client_test.go`: stalled TCP peer + `WriteTimeout=100ms` → client `Write` returns `net.Error` with `Timeout()==true` within 0.1s.