### PR TITLE
Add Server.Close to stop Serve and release the listening port

### DIFF
--- a/diam/server.go
+++ b/diam/server.go
@@ -647,6 +647,71 @@ type Server struct {
 	// Handlers that mutate shared per-connection state must synchronize
 	// themselves.
 	MaxConcurrentHandlers int
+
+	mu        sync.Mutex
+	listeners map[net.Listener]struct{}
+	closed    bool
+}
+
+// ErrServerClosed is returned by Server.Serve and Server.ListenAndServe(TLS)
+// after a call to Server.Close.
+var ErrServerClosed = fmt.Errorf("diam: Server closed")
+
+// Close immediately closes all listeners registered with the server. It does
+// not affect already-accepted connections or in-flight handlers; those
+// continue to run until their read loop exits naturally or their underlying
+// connection is closed by the peer. After Close, Server.Serve returns
+// ErrServerClosed and no new connections are accepted.
+func (srv *Server) Close() error {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	srv.closed = true
+	var firstErr error
+	for l := range srv.listeners {
+		if err := l.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	srv.listeners = nil
+	return firstErr
+}
+
+func (srv *Server) trackListener(l net.Listener, add bool) bool {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if add {
+		if srv.closed {
+			return false
+		}
+		if srv.listeners == nil {
+			srv.listeners = make(map[net.Listener]struct{})
+		}
+		srv.listeners[l] = struct{}{}
+		return true
+	}
+	delete(srv.listeners, l)
+	return true
+}
+
+func (srv *Server) isClosed() bool {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	return srv.closed
+}
+
+// onceCloseListener wraps a net.Listener so that Close is idempotent.
+// Used internally by ListenAndServe(TLS) so the defer l.Close() and
+// Server.Close do not both close the underlying listener, which triggers
+// file-descriptor reuse races on SCTP (see 29cbaef).
+type onceCloseListener struct {
+	net.Listener
+	once     sync.Once
+	closeErr error
+}
+
+func (oc *onceCloseListener) Close() error {
+	oc.once.Do(func() { oc.closeErr = oc.Listener.Close() })
+	return oc.closeErr
 }
 
 // serverHandler delegates to either the server's Handler or DefaultServeMux.
@@ -680,6 +745,7 @@ func (srv *Server) ListenAndServe() error {
 	if e != nil {
 		return e
 	}
+	l = &onceCloseListener{Listener: l}
 	defer l.Close()
 	return srv.Serve(l)
 }
@@ -688,11 +754,19 @@ func (srv *Server) ListenAndServe() error {
 // new service goroutine for each. The service goroutines read requests and
 // then call srv.Handler to reply to them.
 // The caller is responsible for closing l when Serve returns.
+// Serve returns ErrServerClosed after srv.Close is called.
 func (srv *Server) Serve(l net.Listener) error {
+	if !srv.trackListener(l, true) {
+		return ErrServerClosed
+	}
+	defer srv.trackListener(l, false)
 	var tempDelay time.Duration // how long to sleep on accept failure
 	for {
 		rw, e := l.Accept()
 		if e != nil {
+			if srv.isClosed() {
+				return ErrServerClosed
+			}
 			if ne, ok := e.(net.Error); ok && ne.Temporary() {
 				if tempDelay == 0 {
 					tempDelay = 5 * time.Millisecond
@@ -788,7 +862,8 @@ func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
 	if err != nil {
 		return err
 	}
-	tlsListener := tls.NewListener(conn, config)
+	var tlsListener net.Listener = tls.NewListener(conn, config)
+	tlsListener = &onceCloseListener{Listener: tlsListener}
 	defer tlsListener.Close()
 	return srv.Serve(tlsListener)
 }

--- a/diam/server_close_test.go
+++ b/diam/server_close_test.go
@@ -1,0 +1,71 @@
+// Copyright 2013-2015 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package diam_test
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+)
+
+// TestServerClose verifies Server.Close unblocks Accept, makes Serve return
+// ErrServerClosed, and releases the listening port so it can be rebound.
+// Regression test for #183.
+func TestServerClose(t *testing.T) {
+	for _, network := range []string{"tcp", "sctp"} {
+		t.Run(network, func(t *testing.T) {
+			ln, err := diam.MultistreamListen(network, "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			addr := ln.Addr().String()
+
+			srv := &diam.Server{Network: network}
+			errc := make(chan error, 1)
+			go func() { errc <- srv.Serve(ln) }()
+
+			time.Sleep(50 * time.Millisecond)
+
+			if err := srv.Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			select {
+			case err := <-errc:
+				if !errors.Is(err, diam.ErrServerClosed) {
+					t.Fatalf("Serve returned %v, want ErrServerClosed", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("Serve did not return after Close")
+			}
+
+			ln2, err := diam.MultistreamListen(network, addr)
+			if err != nil {
+				t.Fatalf("rebind %s %s: %v", network, addr, err)
+			}
+			ln2.Close()
+		})
+	}
+}
+
+// TestServerCloseBeforeServe ensures Serve returns ErrServerClosed immediately
+// when called after Close, without touching the listener.
+func TestServerCloseBeforeServe(t *testing.T) {
+	srv := &diam.Server{}
+	srv.Close()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	if err := srv.Serve(ln); !errors.Is(err, diam.ErrServerClosed) {
+		t.Fatalf("Serve after Close returned %v, want ErrServerClosed", err)
+	}
+}


### PR DESCRIPTION
## Summary
- New `Server.Close() error` and `ErrServerClosed` sentinel, modeled after `net/http`.
- `Serve` tracks its listener and returns `ErrServerClosed` after `Close` instead of the raw "use of closed network connection" error.
- `ListenAndServe`/`ListenAndServeTLS` wrap the listener in a `sync.Once`-guarded `onceCloseListener` to avoid double-close with `Server.Close` (same FD-reuse race 29cbaef addressed for SCTP+TLS).

## Why
Fixes #183. Previously there was no way to stop a running server without exiting the process. Users of `ListenAndServe` had no handle to the internal listener to close it. `Server.Close` releases the bind port immediately; accepted connections and in-flight handlers keep running and exit naturally.

## Test plan
- [x] `go test ./...` passes
- [x] `go test -race ./diam/` passes
- [x] New `TestServerClose` in `diam/server_close_test.go`: `Serve` running on TCP and SCTP, `srv.Close()` → `Serve` returns `ErrServerClosed` within 2s, port rebinds immediately. Confirms `SCTPListener.Close` does unblock `AcceptSCTP` in the current `ishidawataru/sctp` version.
- [x] `TestServerCloseBeforeServe`: `Close` before `Serve` → `Serve` returns `ErrServerClosed` without touching the listener.