### PR TITLE
Add Server.OnNewConnection lifecycle hook

### DIFF
--- a/diam/server.go
+++ b/diam/server.go
@@ -204,6 +204,9 @@ func (c *conn) serve() {
 		c.tlsState = &tls.ConnectionState{}
 		*c.tlsState = tlsConn.ConnectionState()
 	}
+	if cb := c.server.OnNewConnection; cb != nil {
+		cb(c.writer)
+	}
 	for {
 		m, err := c.readMessage()
 		if err != nil {
@@ -647,6 +650,22 @@ type Server struct {
 	// Handlers that mutate shared per-connection state must synchronize
 	// themselves.
 	MaxConcurrentHandlers int
+
+	// OnNewConnection, if non-nil, is invoked once per accepted connection
+	// after the transport is fully established (TLS handshake complete, if
+	// applicable) and before the read loop starts. It runs in the
+	// connection's serve goroutine, so long-running work will delay message
+	// processing on that connection. Type-assert to CloseNotifier to detect
+	// disconnection:
+	//
+	//	srv.OnNewConnection = func(c diam.Conn) {
+	//		log.Printf("up: %s", c.RemoteAddr())
+	//		go func() {
+	//			<-c.(diam.CloseNotifier).CloseNotify()
+	//			log.Printf("down: %s", c.RemoteAddr())
+	//		}()
+	//	}
+	OnNewConnection func(Conn)
 
 	mu        sync.Mutex
 	listeners map[net.Listener]struct{}

--- a/diam/server_onconn_test.go
+++ b/diam/server_onconn_test.go
@@ -1,0 +1,61 @@
+// Copyright 2013-2015 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package diam_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+)
+
+// TestServerOnNewConnection verifies that Server.OnNewConnection fires once
+// per accepted connection with a Conn that can be used with CloseNotify to
+// detect disconnection. Regression test for #152.
+func TestServerOnNewConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	opened := make(chan diam.Conn, 1)
+	srv := &diam.Server{
+		OnNewConnection: func(c diam.Conn) { opened <- c },
+	}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- srv.Serve(ln) }()
+	defer srv.Close()
+
+	peer, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var c diam.Conn
+	select {
+	case c = <-opened:
+	case <-time.After(time.Second):
+		t.Fatal("OnNewConnection not called")
+	}
+
+	if c.RemoteAddr() == nil {
+		t.Fatal("conn RemoteAddr is nil")
+	}
+
+	cn, ok := c.(diam.CloseNotifier)
+	if !ok {
+		t.Fatal("Conn does not implement CloseNotifier")
+	}
+	closed := cn.CloseNotify()
+	peer.Close()
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("CloseNotify did not fire after peer close")
+	}
+}


### PR DESCRIPTION
## Summary
- New optional \`Server.OnNewConnection func(Conn)\` field, invoked once per accepted connection after TLS handshake (if any) and before the read loop.
- Disconnection is observed via the existing \`CloseNotifier\` interface; no second callback needed.

## Why
Fixes #152. There was no way to observe TCP/SCTP connection events without parsing a CER or subscribing to the state machine's \`HandshakeNotify\`. Users wanted a simple hook for metrics, per-IP filtering, and up/down logging.

Example:
\`\`\`go
srv.OnNewConnection = func(c diam.Conn) {
    log.Printf("up: %s", c.RemoteAddr())
    go func() {
        <-c.(diam.CloseNotifier).CloseNotify()
        log.Printf("down: %s", c.RemoteAddr())
    }()
}
\`\`\`

## Test plan
- [x] \`go test ./...\` passes
- [x] \`go test -race ./diam/\` passes
- [x] New \`TestServerOnNewConnection\` in \`diam/server_onconn_test.go\`: callback fires once with a usable \`Conn\`; peer close propagates via \`CloseNotify\` within 1s.