### PR TITLE
Add sm.Settings.OnCER and OnDWR pre-hooks

### DIFF
--- a/diam/sm/hooks_test.go
+++ b/diam/sm/hooks_test.go
@@ -1,0 +1,119 @@
+// Copyright 2013-2015 go-diameter authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package sm
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/fiorix/go-diameter/v4/diam/diamtest"
+	"github.com/fiorix/go-diameter/v4/diam/dict"
+)
+
+// TestOnCERHook verifies that Settings.OnCER fires on a received CER before
+// the state machine's default handler, and that the default handshake still
+// completes. Regression test for #150.
+func TestOnCERHook(t *testing.T) {
+	var onCERCalls int32
+	settings := *serverSettings
+	settings.OnCER = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.CapabilitiesExchange {
+			t.Errorf("OnCER invoked for non-CER command %d", m.Header.CommandCode)
+		}
+		atomic.AddInt32(&onCERCalls, 1)
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	m := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := m.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-sm.HandshakeNotify():
+	case <-time.After(2 * time.Second):
+		t.Fatal("handshake did not complete after OnCER hook")
+	}
+
+	if got := atomic.LoadInt32(&onCERCalls); got != 1 {
+		t.Fatalf("OnCER calls = %d, want 1", got)
+	}
+}
+
+// TestOnDWRHook verifies that Settings.OnDWR fires on a received DWR after
+// the handshake and before the default DWR handler responds with DWA.
+func TestOnDWRHook(t *testing.T) {
+	onDWR := make(chan struct{}, 1)
+	settings := *serverSettings
+	settings.OnDWR = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.DeviceWatchdog {
+			t.Errorf("OnDWR invoked for non-DWR command %d", m.Header.CommandCode)
+		}
+		onDWR <- struct{}{}
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	cer := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	cer.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	cer.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	cer.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	cer.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	cer.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	cer.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	cer.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	cer.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := cer.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-sm.HandshakeNotify():
+	case <-time.After(2 * time.Second):
+		t.Fatal("handshake did not complete")
+	}
+
+	dwr := diam.NewRequest(diam.DeviceWatchdog, 0, dict.Default)
+	dwr.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	dwr.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	if _, err := dwr.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-onDWR:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnDWR hook did not fire")
+	}
+}

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -71,6 +71,18 @@ type Settings struct {
 
 	// Dict is an optional dictionary parser. If nil, dict.Default is used.
 	Dict *dict.Parser
+
+	// OnCER, if non-nil, is invoked when a CER is received, before the
+	// state machine processes it. Useful for logging, metrics, or access
+	// control. The default handshake logic runs after OnCER returns.
+	// Closing the connection from the hook is honored and aborts the
+	// handshake.
+	OnCER diam.HandlerFunc
+
+	// OnDWR, if non-nil, is invoked when a DWR is received (after the
+	// peer has passed the handshake) before the state machine responds
+	// with DWA. Same semantics as OnCER.
+	OnDWR diam.HandlerFunc
 }
 
 var (
@@ -107,11 +119,26 @@ func New(settings *Settings) *StateMachine {
 		hsNotifyc:     make(chan diam.Conn, 1000),
 		supportedApps: PrepareSupportedApps(dp),
 	}
-	sm.mux.Handle("CER", handleCER(sm))
-	sm.mux.Handle("DWR", handshakeOK(handleDWR(sm)))
-	sm.mux.HandleIdx(baseCERIdx, handleCER(sm))
-	sm.mux.HandleIdx(baseDWRIdx, handleDWR(sm))
+	cerHandler := chainPreHook(settings.OnCER, handleCER(sm))
+	dwrHandler := chainPreHook(settings.OnDWR, handleDWR(sm))
+	sm.mux.Handle("CER", cerHandler)
+	sm.mux.Handle("DWR", handshakeOK(dwrHandler))
+	sm.mux.HandleIdx(baseCERIdx, cerHandler)
+	sm.mux.HandleIdx(baseDWRIdx, dwrHandler)
 	return sm
+}
+
+// chainPreHook returns a HandlerFunc that invokes pre (if non-nil) before
+// next. Used to install the Settings.OnCER / Settings.OnDWR hooks without
+// changing the default handler.
+func chainPreHook(pre diam.HandlerFunc, next diam.HandlerFunc) diam.HandlerFunc {
+	if pre == nil {
+		return next
+	}
+	return func(c diam.Conn, m *diam.Message) {
+		pre(c, m)
+		next(c, m)
+	}
 }
 
 // Settings return the Settings object used by this StateMachine.


### PR DESCRIPTION
## Summary
- New \`Settings.OnCER\` and \`Settings.OnDWR\` (\`diam.HandlerFunc\`) fields on \`sm.Settings\`, invoked before the default state machine handlers for CER and DWR.
- Default handshake and watchdog responses unchanged.
- No effect on \`HandleFunc\` / \`HandleIdx\` — they still reject overriding CER/CEA/DWR to protect the handshake.

## Why
Fixes #150. \`sm.HandleFunc\` and \`sm.HandleIdx\` refuse to let users register handlers for "CER", "CEA", and "DWR" so the handshake stays intact, and \`HandshakeNotify\` only fires on successful completion. Users running a state machine wanted pre-hooks for logging, metrics, and per-peer access control without owning the full handshake.

Example:
\`\`\`go
settings := &sm.Settings{
    OriginHost: "hss", OriginRealm: "test",
    OnCER: func(c diam.Conn, m *diam.Message) {
        log.Printf("CER from %s", c.RemoteAddr())
    },
    OnDWR: func(c diam.Conn, m *diam.Message) {
        log.Printf("DWR from %s", c.RemoteAddr())
    },
}
\`\`\`

Closing the connection from a hook (e.g. to reject a peer based on OriginHost) is honored and aborts the handshake.

## Out of scope / follow-ups
- Client-side CEA/DWA receive hooks (registered dynamically in \`client.go\`). Can be added if there is demand.
- \`diamtest.Server.Close\` still only closes the listener, which causes a stale "accept error: use of closed network connection" log line after \`#231\`. Easy follow-up: have it call \`s.Config.Close()\` too.

## Test plan
- [x] \`go test ./...\` passes
- [x] \`go test -race ./diam/sm/\` passes
- [x] New \`TestOnCERHook\`: OnCER fires exactly once on CER, default handshake still completes.
- [x] New \`TestOnDWRHook\`: OnDWR fires on DWR after handshake, default DWA still issued.