### PR TITLE
diamtest: close the Server, not just its Listener

### DIFF
--- a/diam/diamtest/server.go
+++ b/diam/diamtest/server.go
@@ -125,7 +125,7 @@ func (s *Server) StartTLS() {
 
 // Close shuts down the server.
 func (s *Server) Close() {
-	s.Listener.Close()
+	s.Config.Close()
 }
 
 // localhostCert is a PEM-encoded TLS cert with SAN IPs


### PR DESCRIPTION
## Summary
- \`diamtest.Server.Close\` now calls \`s.Config.Close()\` instead of closing the listener directly.

## Why
After #231 added \`diam.Server.Close\`, \`diamtest.Server.Close\` was still closing only the listener. The underlying \`diam.Server\` never learned the listener was gone, so its accept loop unwound through the generic error path and printed a stale \`accept error: use of closed network connection\` line on every test that used \`diamtest\`.

\`diam.Server.Close\` closes all tracked listeners and makes \`Serve\` return \`ErrServerClosed\` cleanly, so the port is still released and no spurious log appears.

(Note: the commit message references \`ab2fad2/#231\` — that SHA is wrong; the correct merge commit for #231 is \`b3e4e26\`.)

## Test plan
- [x] \`go test ./...\` passes
- [x] Verified the \`accept error: use of closed network connection\` log is gone from \`-v\` runs of \`./diam/sm/\` tests.