### PR TITLE
sm: make Inband-Security-Id configurable in Client CER

### DIFF
--- a/diam/sm/client.go
+++ b/diam/sm/client.go
@@ -57,6 +57,7 @@ type Client struct {
 	AcctApplicationID           []*diam.AVP   // Acct applications
 	AuthApplicationID           []*diam.AVP   // Auth applications
 	VendorSpecificApplicationID []*diam.AVP   // Vendor specific applications
+	InbandSecurityID            uint32        // Inband-Security-Id for CER: 0=NO_INBAND_SECURITY (default), 1=TLS (RFC 6733 §5.3.1)
 }
 
 // Dial calls the address set as ip:port, performs a handshake and optionally
@@ -265,7 +266,7 @@ func (cli *Client) makeCER(hostIPAddresses []datatype.Address) *diam.Message {
 			m.AddAVP(a)
 		}
 	}
-	m.NewAVP(avp.InbandSecurityID, avp.Mbit, 0, datatype.Unsigned32(0))
+	m.NewAVP(avp.InbandSecurityID, avp.Mbit, 0, datatype.Unsigned32(cli.InbandSecurityID))
 	if cli.AcctApplicationID != nil {
 		for _, a := range cli.AcctApplicationID {
 			m.AddAVP(a)

--- a/diam/sm/client_test.go
+++ b/diam/sm/client_test.go
@@ -367,3 +367,77 @@ func TestClient_Conn_LocalAddresses_Complex(t *testing.T) {
 		t.Fatalf("Wrong IP address found in list of local addresses, expected: %s, actual: %s", expected, actual)
 	}
 }
+
+func TestClient_InbandSecurityID_Default(t *testing.T) {
+	// Verify that the default (zero value) sends Inband-Security-Id=0 in CER.
+	var received uint32
+	mux := diam.NewServeMux()
+	mux.HandleFunc("CER", func(c diam.Conn, m *diam.Message) {
+		a, _ := m.FindAVP(avp.InbandSecurityID, 0)
+		if a != nil {
+			received = uint32(a.Data.(datatype.Unsigned32))
+		}
+		// Send a valid CEA back.
+		cea := m.Answer(diam.Success)
+		cea.NewAVP(avp.OriginHost, avp.Mbit, 0, serverSettings.OriginHost)
+		cea.NewAVP(avp.OriginRealm, avp.Mbit, 0, serverSettings.OriginRealm)
+		cea.NewAVP(avp.HostIPAddress, avp.Mbit, 0, datatype.Address(net.ParseIP("127.0.0.1")))
+		cea.NewAVP(avp.VendorID, avp.Mbit, 0, serverSettings.VendorID)
+		cea.NewAVP(avp.ProductName, 0, 0, serverSettings.ProductName)
+		cea.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3))
+		cea.WriteTo(c)
+	})
+	srv := diamtest.NewServer(mux, dict.Default)
+	defer srv.Close()
+	cli := &Client{
+		Handler: New(clientSettings),
+		AcctApplicationID: []*diam.AVP{
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
+		},
+	}
+	c, err := cli.Dial(srv.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if received != 0 {
+		t.Fatalf("Expected Inband-Security-Id=0, got %d", received)
+	}
+}
+
+func TestClient_InbandSecurityID_TLS(t *testing.T) {
+	// Verify that setting InbandSecurityID=1 sends that value in CER.
+	var received uint32
+	mux := diam.NewServeMux()
+	mux.HandleFunc("CER", func(c diam.Conn, m *diam.Message) {
+		a, _ := m.FindAVP(avp.InbandSecurityID, 0)
+		if a != nil {
+			received = uint32(a.Data.(datatype.Unsigned32))
+		}
+		cea := m.Answer(diam.Success)
+		cea.NewAVP(avp.OriginHost, avp.Mbit, 0, serverSettings.OriginHost)
+		cea.NewAVP(avp.OriginRealm, avp.Mbit, 0, serverSettings.OriginRealm)
+		cea.NewAVP(avp.HostIPAddress, avp.Mbit, 0, datatype.Address(net.ParseIP("127.0.0.1")))
+		cea.NewAVP(avp.VendorID, avp.Mbit, 0, serverSettings.VendorID)
+		cea.NewAVP(avp.ProductName, 0, 0, serverSettings.ProductName)
+		cea.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3))
+		cea.WriteTo(c)
+	})
+	srv := diamtest.NewServer(mux, dict.Default)
+	defer srv.Close()
+	cli := &Client{
+		Handler: New(clientSettings),
+		AcctApplicationID: []*diam.AVP{
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(3)),
+		},
+		InbandSecurityID: 1,
+	}
+	c, err := cli.Dial(srv.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	if received != 1 {
+		t.Fatalf("Expected Inband-Security-Id=1, got %d", received)
+	}
+}


### PR DESCRIPTION
Add `InbandSecurityID` field to `sm.Client` allowing callers to propose TLS (value 1) during CER/CEA exchange per RFC 6733 §5.3.1. The zero value preserves existing behavior (NO_INBAND_SECURITY).

## Changes
- Add `InbandSecurityID uint32` field to `sm.Client` struct
- Use the field value in `makeCER()` instead of hardcoded `0`
- Add two tests verifying default (0) and TLS (1) values are sent

## RFC Reference
RFC 6733 §5.3.1 defines Inband-Security-Id AVP (code 299) with values 0 (NO_INBAND_SECURITY) and 1 (TLS).

All existing tests pass.

Fixes #239