### PR TITLE
datatype: add DiameterURI Parse() method (RFC 6733 §4.3)

### DIFF
--- a/diam/datatype/diamuri.go
+++ b/diam/datatype/diamuri.go
@@ -4,7 +4,11 @@
 
 package datatype
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // DiameterURI data type.
 type DiameterURI OctetString
@@ -26,23 +30,23 @@ func (s DiameterURI) Parse() (*ParsedDiameterURI, error) {
 	raw := string(s)
 	p := &ParsedDiameterURI{Transport: "tcp", Protocol: "diameter"}
 	switch {
-	case len(raw) > 7 && raw[:7] == "aaas://":
+	case len(raw) > 7 && strings.EqualFold(raw[:7], "aaas://"):
 		p.Secure = true
 		p.Port = 5868
 		raw = raw[7:]
-	case len(raw) > 6 && raw[:6] == "aaa://":
+	case len(raw) > 6 && strings.EqualFold(raw[:6], "aaa://"):
 		p.Port = 3868
 		raw = raw[6:]
 	default:
 		return nil, fmt.Errorf("diamuri: invalid scheme in %q", string(s))
 	}
 	// Extract ";protocol=" (must come after ";transport=" per ABNF)
-	if i := indexOf(raw, ";protocol="); i >= 0 {
+	if i := strings.Index(raw, ";protocol="); i >= 0 {
 		p.Protocol = raw[i+10:]
 		raw = raw[:i]
 	}
 	// Extract ";transport="
-	if i := indexOf(raw, ";transport="); i >= 0 {
+	if i := strings.Index(raw, ";transport="); i >= 0 {
 		p.Transport = raw[i+11:]
 		raw = raw[:i]
 	}
@@ -52,21 +56,21 @@ func (s DiameterURI) Parse() (*ParsedDiameterURI, error) {
 	}
 	if raw[0] == '[' {
 		// IPv6 literal: [addr]:port
-		if end := indexOf(raw, "]"); end >= 0 {
+		if end := strings.Index(raw, "]"); end >= 0 {
 			p.FQDN = raw[1:end]
 			raw = raw[end+1:]
 		}
-	} else if i := lastIndexByte(raw, ':'); i >= 0 {
+	} else if i := strings.LastIndexByte(raw, ':'); i >= 0 {
 		p.FQDN = raw[:i]
 		portStr := raw[i+1:]
-		var port uint16
-		for _, c := range portStr {
-			if c < '0' || c > '9' {
-				return nil, fmt.Errorf("diamuri: invalid port in %q", string(s))
-			}
-			port = port*10 + uint16(c-'0')
+		if portStr == "" {
+			return nil, fmt.Errorf("diamuri: empty port in %q", string(s))
 		}
-		p.Port = port
+		port, err := strconv.ParseUint(portStr, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("diamuri: invalid port in %q", string(s))
+		}
+		p.Port = uint16(port)
 		raw = ""
 	}
 	if p.FQDN == "" {
@@ -76,24 +80,6 @@ func (s DiameterURI) Parse() (*ParsedDiameterURI, error) {
 		return nil, fmt.Errorf("diamuri: missing FQDN in %q", string(s))
 	}
 	return p, nil
-}
-
-func indexOf(s, substr string) int {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
-}
-
-func lastIndexByte(s string, c byte) int {
-	for i := len(s) - 1; i >= 0; i-- {
-		if s[i] == c {
-			return i
-		}
-	}
-	return -1
 }
 
 // DecodeDiameterURI decodes a DiameterURI from byte array.

--- a/diam/datatype/diamuri.go
+++ b/diam/datatype/diamuri.go
@@ -9,6 +9,93 @@ import "fmt"
 // DiameterURI data type.
 type DiameterURI OctetString
 
+// ParsedDiameterURI holds the components of a DiameterURI as defined in RFC 6733 §4.3.
+type ParsedDiameterURI struct {
+	Secure    bool   // true for "aaas://" scheme, false for "aaa://"
+	FQDN      string // hostname
+	Port      uint16 // default 3868 (aaa) or 5868 (aaas)
+	Transport string // "tcp" or "sctp"; default "tcp"
+	Protocol  string // "diameter", "radius", or "tacacsplus"; default "diameter"
+}
+
+// Parse parses the DiameterURI per RFC 6733 §4.3 ABNF:
+//
+//	"aaa://" FQDN [ ":" port ] [ ";transport=" transport ] [ ";protocol=" protocol ]
+//	"aaas://" FQDN [ ":" port ] [ ";transport=" transport ] [ ";protocol=" protocol ]
+func (s DiameterURI) Parse() (*ParsedDiameterURI, error) {
+	raw := string(s)
+	p := &ParsedDiameterURI{Transport: "tcp", Protocol: "diameter"}
+	switch {
+	case len(raw) > 7 && raw[:7] == "aaas://":
+		p.Secure = true
+		p.Port = 5868
+		raw = raw[7:]
+	case len(raw) > 6 && raw[:6] == "aaa://":
+		p.Port = 3868
+		raw = raw[6:]
+	default:
+		return nil, fmt.Errorf("diamuri: invalid scheme in %q", string(s))
+	}
+	// Extract ";protocol=" (must come after ";transport=" per ABNF)
+	if i := indexOf(raw, ";protocol="); i >= 0 {
+		p.Protocol = raw[i+10:]
+		raw = raw[:i]
+	}
+	// Extract ";transport="
+	if i := indexOf(raw, ";transport="); i >= 0 {
+		p.Transport = raw[i+11:]
+		raw = raw[:i]
+	}
+	// Remaining is FQDN [ ":" port ]
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("diamuri: missing FQDN in %q", string(s))
+	}
+	if raw[0] == '[' {
+		// IPv6 literal: [addr]:port
+		if end := indexOf(raw, "]"); end >= 0 {
+			p.FQDN = raw[1:end]
+			raw = raw[end+1:]
+		}
+	} else if i := lastIndexByte(raw, ':'); i >= 0 {
+		p.FQDN = raw[:i]
+		portStr := raw[i+1:]
+		var port uint16
+		for _, c := range portStr {
+			if c < '0' || c > '9' {
+				return nil, fmt.Errorf("diamuri: invalid port in %q", string(s))
+			}
+			port = port*10 + uint16(c-'0')
+		}
+		p.Port = port
+		raw = ""
+	}
+	if p.FQDN == "" {
+		p.FQDN = raw
+	}
+	if p.FQDN == "" {
+		return nil, fmt.Errorf("diamuri: missing FQDN in %q", string(s))
+	}
+	return p, nil
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
 // DecodeDiameterURI decodes a DiameterURI from byte array.
 func DecodeDiameterURI(b []byte) (Type, error) {
 	d := make([]byte, len(b))

--- a/diam/datatype/diamuri_test.go
+++ b/diam/datatype/diamuri_test.go
@@ -70,10 +70,16 @@ func TestDiameterURI_Parse(t *testing.T) {
 		{"aaa://host.example.com;transport=sctp", false, "host.example.com", 3868, "sctp", "diameter", false},
 		{"aaa://host.example.com:3868;transport=tcp;protocol=diameter", false, "host.example.com", 3868, "tcp", "diameter", false},
 		{"aaa://host.example.com;protocol=radius", false, "host.example.com", 3868, "tcp", "radius", false},
+		// Case-insensitive scheme (RFC 6733 §4.3)
+		{"AAA://host.example.com", false, "host.example.com", 3868, "tcp", "diameter", false},
+		{"AAAS://host.example.com", true, "host.example.com", 5868, "tcp", "diameter", false},
+		{"Aaa://host.example.com", false, "host.example.com", 3868, "tcp", "diameter", false},
 		// Error cases
 		{"http://host.example.com", false, "", 0, "", "", true},
 		{"", false, "", 0, "", "", true},
 		{"aaa://", false, "", 0, "", "", true},
+		{"aaa://host.example.com:", false, "", 0, "", "", true},      // empty port
+		{"aaa://host.example.com:99999", false, "", 0, "", "", true}, // port overflow
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/diam/datatype/diamuri_test.go
+++ b/diam/datatype/diamuri_test.go
@@ -52,3 +52,57 @@ func TestDecodeDiameterURI(t *testing.T) {
 		t.Fatalf("Unexpected string. Want 'hello, world', have %q", v)
 	}
 }
+
+func TestDiameterURI_Parse(t *testing.T) {
+	tests := []struct {
+		input     string
+		secure    bool
+		fqdn      string
+		port      uint16
+		transport string
+		protocol  string
+		wantErr   bool
+	}{
+		{"aaa://host.example.com", false, "host.example.com", 3868, "tcp", "diameter", false},
+		{"aaas://host.example.com", true, "host.example.com", 5868, "tcp", "diameter", false},
+		{"aaa://host.example.com:6666", false, "host.example.com", 6666, "tcp", "diameter", false},
+		{"aaas://host.example.com:5868;transport=tcp", true, "host.example.com", 5868, "tcp", "diameter", false},
+		{"aaa://host.example.com;transport=sctp", false, "host.example.com", 3868, "sctp", "diameter", false},
+		{"aaa://host.example.com:3868;transport=tcp;protocol=diameter", false, "host.example.com", 3868, "tcp", "diameter", false},
+		{"aaa://host.example.com;protocol=radius", false, "host.example.com", 3868, "tcp", "radius", false},
+		// Error cases
+		{"http://host.example.com", false, "", 0, "", "", true},
+		{"", false, "", 0, "", "", true},
+		{"aaa://", false, "", 0, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			uri := DiameterURI(tt.input)
+			p, err := uri.Parse()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if p.Secure != tt.secure {
+				t.Errorf("Secure: got %v, want %v", p.Secure, tt.secure)
+			}
+			if p.FQDN != tt.fqdn {
+				t.Errorf("FQDN: got %q, want %q", p.FQDN, tt.fqdn)
+			}
+			if p.Port != tt.port {
+				t.Errorf("Port: got %d, want %d", p.Port, tt.port)
+			}
+			if p.Transport != tt.transport {
+				t.Errorf("Transport: got %q, want %q", p.Transport, tt.transport)
+			}
+			if p.Protocol != tt.protocol {
+				t.Errorf("Protocol: got %q, want %q", p.Protocol, tt.protocol)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a `Parse()` method to `DiameterURI` that extracts scheme (`aaa://` vs `aaas://`), FQDN, port, transport, and protocol per the RFC 6733 §4.3 ABNF.

## Changes
- Add `ParsedDiameterURI` struct with Secure, FQDN, Port, Transport, Protocol fields
- Add `Parse()` method to `DiameterURI` type
- Defaults: `aaa://` → port 3868, `aaas://` → port 5868, transport=tcp, protocol=diameter
- Add 10 test cases (valid URIs + error cases)

## RFC Reference
RFC 6733 §4.3 defines:
```
"aaa://" FQDN [ ":" port ] [ ";transport=" transport ] [ ";protocol=" protocol ]
"aaas://" FQDN [ ":" port ] [ ";transport=" transport ] [ ";protocol=" protocol ]
```

Backwards-compatible: the raw OctetString wire encoding is unchanged.

Fixes #237