### PR TITLE
sm: accept Inband-Security-Id=1 when TLS is already established

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -28,7 +28,7 @@ func handleCER(sm *StateMachine) diam.HandlerFunc {
 			return
 		}
 		cer := new(smparser.CER)
-		_, err := cer.Parse(m, smparser.Server)
+		_, err := cer.ParseWithSecurity(m, smparser.Server, c.TLS() != nil)
 		if err != nil {
 			err = errorCEA(sm, c, m, cer, err)
 			if err != nil {

--- a/diam/sm/smparser/cer.go
+++ b/diam/sm/smparser/cer.go
@@ -31,6 +31,14 @@ type CER struct {
 // we don't support in our dictionary) and an error. Another cause
 // for error is the presence of Inband Security, we don't support that.
 func (cer *CER) Parse(m *diam.Message, localRole Role) (failedAVP *diam.AVP, err error) {
+	return cer.ParseWithSecurity(m, localRole, false)
+}
+
+// ParseWithSecurity is like Parse but accepts a tlsActive flag. When
+// tlsActive is true, Inband-Security-Id=1 (TLS) is accepted because
+// the transport is already secured — per RFC 6733 §5.3.1 the peer is
+// simply declaring its TLS capability which is already satisfied.
+func (cer *CER) ParseWithSecurity(m *diam.Message, localRole Role, tlsActive bool) (failedAVP *diam.AVP, err error) {
 	if err = m.Unmarshal(cer); err != nil {
 		return nil, err
 	}
@@ -38,7 +46,7 @@ func (cer *CER) Parse(m *diam.Message, localRole Role) (failedAVP *diam.AVP, err
 		return nil, err
 	}
 	if cer.InbandSecurityID != nil {
-		if v := cer.InbandSecurityID.Data.(datatype.Unsigned32); v != 0 {
+		if v := cer.InbandSecurityID.Data.(datatype.Unsigned32); v != 0 && !tlsActive {
 			return nil, ErrNoCommonSecurity
 		}
 	}

--- a/diam/sm/smparser/cer_test.go
+++ b/diam/sm/smparser/cer_test.go
@@ -271,3 +271,32 @@ func TestCER_FailedVSAuthAppID(t *testing.T) {
 		t.Fatal("Unexpected error:", err)
 	}
 }
+
+func TestCER_InbandSecurity_TLSActive(t *testing.T) {
+	// When TLS is already active, Inband-Security-Id=1 should be accepted.
+	m := diam.NewRequest(diam.CapabilitiesExchange, 0, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity("foobar"))
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity("test"))
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.InbandSecurityID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	cer := new(CER)
+	_, err := cer.ParseWithSecurity(m, Client, true)
+	if err != nil {
+		t.Fatalf("Expected no error when TLS active, got: %v", err)
+	}
+}
+
+func TestCER_InbandSecurity_NoTLS(t *testing.T) {
+	// When TLS is NOT active, Inband-Security-Id=1 should still be rejected.
+	m := diam.NewRequest(diam.CapabilitiesExchange, 0, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity("foobar"))
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity("test"))
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.InbandSecurityID, avp.Mbit, 0, datatype.Unsigned32(1))
+	cer := new(CER)
+	_, err := cer.ParseWithSecurity(m, Server, false)
+	if err != ErrNoCommonSecurity {
+		t.Fatalf("Expected ErrNoCommonSecurity, got: %v", err)
+	}
+}


### PR DESCRIPTION
Per RFC 6733 §5.3.1, a peer may include Inband-Security-Id=1 in CER to declare TLS capability. When the connection is already TLS-secured, this should be accepted rather than rejected with NO_COMMON_SECURITY.

## Changes
- Add `ParseWithSecurity(msg, role, tlsActive)` to CER parser
- Existing `Parse()` preserves backwards-compatible behavior (rejects on plain TCP)
- Update `handleCER` to pass `c.TLS() != nil` to the parser
- Add two unit tests

## RFC Reference
RFC 6733 §5.3.1, §6.2: When TLS is already established on the transport, Inband-Security-Id=1 simply declares the peer's TLS capability — the security requirement is already satisfied.

All existing tests pass (including TestHandleCER_InbandSecurity which verifies rejection on plain TCP).

Fixes #236