### PR TITLE
sm: implement post-CER/CEA TLS upgrade (RFC 6733 §6.2)

### DIFF
--- a/diam/server.go
+++ b/diam/server.go
@@ -67,10 +67,15 @@ type CloseNotifier interface {
 //	    err := u.StartTLS(tlsConfig)
 //	}
 type TLSUpgrader interface {
-	// StartTLS upgrades the underlying connection to TLS. On the server
-	// side, cfg is used as tls.Server config; on the client side as
-	// tls.Client config. Must be called before any further reads/writes.
+	// StartTLS upgrades the underlying connection to TLS using
+	// server-side parameters (tls.Server). Must be called from within
+	// a handler before the next read.
 	StartTLS(cfg *tls.Config) error
+
+	// StartTLSClient upgrades the underlying connection to TLS using
+	// client-side parameters (tls.Client). Must be called from within
+	// a handler before the next read.
+	StartTLSClient(cfg *tls.Config) error
 }
 
 // A liveSwitchReader is a switchReader that's safe for concurrent
@@ -408,16 +413,38 @@ func (w *response) Connection() net.Conn {
 	return w.conn.rwc
 }
 
-// StartTLS upgrades the underlying plain TCP connection to TLS.
-// Implements the TLSUpgrader interface for RFC 6733 §6.2 in-band
-// TLS negotiation after CER/CEA exchange.
+// StartTLS upgrades the underlying plain TCP connection to TLS using
+// server-side parameters (tls.Server).
+//
+// Concurrency safety: StartTLS swaps the connection's underlying reader
+// and writer. It is only safe to call from within a message handler
+// (e.g. handleCER) before the serve loop reads the next message. The
+// serve loop blocks on the handler, so no concurrent read is in progress
+// at that point. Do NOT call StartTLS from a separate goroutine while
+// the connection is actively reading.
 func (w *response) StartTLS(cfg *tls.Config) error {
+	return w.startTLS(cfg, true)
+}
+
+// StartTLSClient upgrades the underlying plain TCP connection to TLS
+// using client-side parameters (tls.Client). Same concurrency
+// constraints as StartTLS apply.
+func (w *response) StartTLSClient(cfg *tls.Config) error {
+	return w.startTLS(cfg, false)
+}
+
+func (w *response) startTLS(cfg *tls.Config, server bool) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.conn.tlsState != nil {
 		return nil // already TLS
 	}
-	tlsConn := tls.Server(w.conn.rwc, cfg)
+	var tlsConn *tls.Conn
+	if server {
+		tlsConn = tls.Server(w.conn.rwc, cfg)
+	} else {
+		tlsConn = tls.Client(w.conn.rwc, cfg)
+	}
 	if err := tlsConn.Handshake(); err != nil {
 		return err
 	}

--- a/diam/server.go
+++ b/diam/server.go
@@ -59,6 +59,20 @@ type CloseNotifier interface {
 	CloseNotify() <-chan struct{}
 }
 
+// TLSUpgrader is implemented by Conns that support upgrading a plain
+// connection to TLS after the CER/CEA exchange (RFC 6733 §6.2).
+// Use a type assertion to check if a Conn supports this:
+//
+//	if u, ok := conn.(diam.TLSUpgrader); ok {
+//	    err := u.StartTLS(tlsConfig)
+//	}
+type TLSUpgrader interface {
+	// StartTLS upgrades the underlying connection to TLS. On the server
+	// side, cfg is used as tls.Server config; on the client side as
+	// tls.Client config. Must be called before any further reads/writes.
+	StartTLS(cfg *tls.Config) error
+}
+
 // A liveSwitchReader is a switchReader that's safe for concurrent
 // reads and switches, if its mutex is held.
 type liveSwitchReader struct {
@@ -392,6 +406,30 @@ func (w *response) SetContext(ctx context.Context) {
 
 func (w *response) Connection() net.Conn {
 	return w.conn.rwc
+}
+
+// StartTLS upgrades the underlying plain TCP connection to TLS.
+// Implements the TLSUpgrader interface for RFC 6733 §6.2 in-band
+// TLS negotiation after CER/CEA exchange.
+func (w *response) StartTLS(cfg *tls.Config) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.conn.tlsState != nil {
+		return nil // already TLS
+	}
+	tlsConn := tls.Server(w.conn.rwc, cfg)
+	if err := tlsConn.Handshake(); err != nil {
+		return err
+	}
+	// Replace the underlying connection and reader.
+	w.conn.rwc = tlsConn
+	w.conn.sr.Lock()
+	w.conn.sr.r = tlsConn
+	w.conn.sr.Unlock()
+	w.conn.buf = bufio.NewReadWriter(bufio.NewReader(&w.conn.sr), bufio.NewWriter(tlsConn))
+	state := tlsConn.ConnectionState()
+	w.conn.tlsState = &state
+	return nil
 }
 
 // The HandlerFunc type is an adapter to allow the use of

--- a/diam/server.go
+++ b/diam/server.go
@@ -66,6 +66,11 @@ type CloseNotifier interface {
 //	if u, ok := conn.(diam.TLSUpgrader); ok {
 //	    err := u.StartTLS(tlsConfig)
 //	}
+//
+// If the TLS handshake fails after a success CEA has already been sent,
+// the connection must be closed. Both peers participate in the TLS
+// handshake so the failure is observable by both sides; sending a
+// second CEA would violate the Diameter protocol.
 type TLSUpgrader interface {
 	// StartTLS upgrades the underlying connection to TLS using
 	// server-side parameters (tls.Server). Must be called from within

--- a/diam/sm/cea.go
+++ b/diam/sm/cea.go
@@ -5,6 +5,8 @@
 package sm
 
 import (
+	"fmt"
+
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/fiorix/go-diameter/v4/diam/sm/smparser"
 	"github.com/fiorix/go-diameter/v4/diam/sm/smpeer"
@@ -17,6 +19,16 @@ func handleCEA(sm *StateMachine, errc chan error) diam.HandlerFunc {
 		if err := cea.Parse(m, smparser.Client); err != nil {
 			errc <- err
 			return
+		}
+		// RFC 6733 §6.2: If we requested Inband-Security-Id=1 and
+		// received a success CEA, upgrade to TLS on the client side.
+		if sm.cfg.TLSConfig != nil && c.TLS() == nil {
+			if u, ok := c.(diam.TLSUpgrader); ok {
+				if err := u.StartTLSClient(sm.cfg.TLSConfig); err != nil {
+					errc <- fmt.Errorf("post-CEA TLS upgrade failed: %w", err)
+					return
+				}
+			}
 		}
 		meta := smpeer.FromCEA(cea)
 		c.SetContext(smpeer.NewContext(c.Context(), meta))

--- a/diam/sm/cea.go
+++ b/diam/sm/cea.go
@@ -22,6 +22,8 @@ func handleCEA(sm *StateMachine, errc chan error) diam.HandlerFunc {
 		}
 		// RFC 6733 §6.2: If we requested Inband-Security-Id=1 and
 		// received a success CEA, upgrade to TLS on the client side.
+		// On failure the connection is closed — both peers observe the
+		// TLS handshake failure directly (no second CEA is possible).
 		if sm.cfg.TLSConfig != nil && c.TLS() == nil {
 			if u, ok := c.(diam.TLSUpgrader); ok {
 				if err := u.StartTLSClient(sm.cfg.TLSConfig); err != nil {

--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -28,7 +28,12 @@ func handleCER(sm *StateMachine) diam.HandlerFunc {
 			return
 		}
 		cer := new(smparser.CER)
-		_, err := cer.ParseWithSecurity(m, smparser.Server, c.TLS() != nil)
+		tlsActive := c.TLS() != nil
+		// Accept Inband-Security-Id=1 when TLS is already active, or
+		// when the conn supports upgrading and we have a TLSConfig.
+		_, canUpgrade := c.(diam.TLSUpgrader)
+		canTLS := tlsActive || (canUpgrade && sm.cfg.TLSConfig != nil)
+		_, err := cer.ParseWithSecurity(m, smparser.Server, canTLS)
 		if err != nil {
 			err = errorCEA(sm, c, m, cer, err)
 			if err != nil {
@@ -50,6 +55,21 @@ func handleCER(sm *StateMachine) diam.HandlerFunc {
 				Error:   err,
 			})
 			return
+		}
+		// RFC 6733 §6.2: If Inband-Security-Id=1 was negotiated and
+		// TLS is not already active, upgrade the connection now.
+		if cer.RequestedSecurity() == 1 && !tlsActive {
+			if u, ok := c.(diam.TLSUpgrader); ok && sm.cfg.TLSConfig != nil {
+				if err := u.StartTLS(sm.cfg.TLSConfig); err != nil {
+					sm.Error(&diam.ErrorReport{
+						Conn:    c,
+						Message: m,
+						Error:   fmt.Errorf("post-CER TLS upgrade failed: %w", err),
+					})
+					c.Close()
+					return
+				}
+			}
 		}
 		meta := smpeer.FromCER(cer)
 		c.SetContext(smpeer.NewContext(ctx, meta))

--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -59,16 +59,26 @@ func handleCER(sm *StateMachine) diam.HandlerFunc {
 		// RFC 6733 §6.2: If Inband-Security-Id=1 was negotiated and
 		// TLS is not already active, upgrade the connection now.
 		if cer.RequestedSecurity() == 1 && !tlsActive {
-			if u, ok := c.(diam.TLSUpgrader); ok && sm.cfg.TLSConfig != nil {
-				if err := u.StartTLS(sm.cfg.TLSConfig); err != nil {
-					sm.Error(&diam.ErrorReport{
-						Conn:    c,
-						Message: m,
-						Error:   fmt.Errorf("post-CER TLS upgrade failed: %w", err),
-					})
-					c.Close()
-					return
-				}
+			u, ok := c.(diam.TLSUpgrader)
+			if !ok || sm.cfg.TLSConfig == nil {
+				// Should not happen (canTLS check above prevents it),
+				// but close defensively.
+				sm.Error(&diam.ErrorReport{
+					Conn:    c,
+					Message: m,
+					Error:   fmt.Errorf("post-CER TLS upgrade: conn does not support TLSUpgrader"),
+				})
+				c.Close()
+				return
+			}
+			if err := u.StartTLS(sm.cfg.TLSConfig); err != nil {
+				sm.Error(&diam.ErrorReport{
+					Conn:    c,
+					Message: m,
+					Error:   fmt.Errorf("post-CER TLS upgrade failed: %w", err),
+				})
+				c.Close()
+				return
 			}
 		}
 		meta := smpeer.FromCER(cer)

--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -58,6 +58,12 @@ func handleCER(sm *StateMachine) diam.HandlerFunc {
 		}
 		// RFC 6733 §6.2: If Inband-Security-Id=1 was negotiated and
 		// TLS is not already active, upgrade the connection now.
+		//
+		// Failure handling: if the TLS handshake fails after a success
+		// CEA has been sent, the connection is closed. Per RFC 6733 §6.2
+		// the TLS handshake begins immediately after CEA — both peers
+		// participate, so a handshake failure is observable by both sides.
+		// Sending a second (failure) CEA would violate the protocol.
 		if cer.RequestedSecurity() == 1 && !tlsActive {
 			u, ok := c.(diam.TLSUpgrader)
 			if !ok || sm.cfg.TLSConfig == nil {

--- a/diam/sm/cer_test.go
+++ b/diam/sm/cer_test.go
@@ -586,3 +586,146 @@ func TestHandleCER_InbandSecurity_WithTLSConfig(t *testing.T) {
 		t.Fatal("No message received")
 	}
 }
+
+func TestInbandTLSUpgrade_EndToEnd(t *testing.T) {
+	// End-to-end test: plain TCP → CER/CEA with Inband-Security-Id=1 → TLS upgrade.
+	// Both server and client perform the TLS handshake after CEA.
+
+	// Generate a self-signed test certificate at runtime.
+	cert, err := tls.X509KeyPair(testCert, testKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverTLSCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	clientTLSCfg := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	// Server settings with TLSConfig to enable inband upgrade.
+	srvSettings := &Settings{
+		OriginHost:       "srv",
+		OriginRealm:      "test",
+		VendorID:         13,
+		ProductName:      "go-diameter",
+		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
+		FirmwareRevision: 1,
+		TLSConfig:        serverTLSCfg,
+	}
+	sm := New(srvSettings)
+
+	// Start a plain TCP server (not pre-TLS).
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	// Client settings with TLSConfig to enable inband upgrade.
+	cliSettings := &Settings{
+		OriginHost:       "cli",
+		OriginRealm:      "test",
+		VendorID:         13,
+		ProductName:      "go-diameter",
+		OriginStateID:    datatype.Unsigned32(time.Now().Unix()),
+		FirmwareRevision: 1,
+		TLSConfig:        clientTLSCfg,
+	}
+
+	cli := &Client{
+		Handler:            New(cliSettings),
+		MaxRetransmits:     3,
+		RetransmitInterval: time.Second,
+		InbandSecurityID:   1, // Request TLS upgrade
+		AcctApplicationID: []*diam.AVP{
+			diam.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001)),
+		},
+	}
+
+	// Dial plain TCP — the CER/CEA exchange + TLS upgrade happens inside.
+	conn, err := cli.Dial(srv.Addr)
+	if err != nil {
+		t.Fatalf("Client.Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// After successful dial, TLS should be active.
+	if conn.TLS() == nil {
+		t.Fatal("Expected TLS to be active after inband upgrade, but conn.TLS() is nil")
+	}
+
+	// Verify we can still exchange messages over the upgraded connection.
+	// Send a DWR and expect a DWA back (the state machine handles DWR automatically).
+	m := diam.NewRequest(diam.DeviceWatchdog, 0, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, cliSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, cliSettings.OriginRealm)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, cliSettings.OriginStateID)
+
+	done := make(chan *diam.Message, 1)
+	cli.Handler.HandleFunc("DWA", func(c diam.Conn, msg *diam.Message) {
+		done <- msg
+	})
+
+	if _, err := m.WriteTo(conn); err != nil {
+		t.Fatalf("Failed to send DWR over TLS connection: %v", err)
+	}
+
+	select {
+	case dwa := <-done:
+		if dwa == nil {
+			t.Fatal("Received nil DWA")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Timed out waiting for DWA over TLS connection")
+	}
+}
+
+// Test certificate with 2048-bit RSA key for TLS upgrade tests.
+// Generated with: openssl req -x509 -newkey rsa:2048 -nodes -subj '/CN=localhost' -addext 'subjectAltName=IP:127.0.0.1,IP:::1'
+var testCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDLDCCAhSgAwIBAgIUQTnWs9bR1QQqy0SDFQfh//Qv/VEwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDUwMTE5MTYwMloXDTM2MDQy
+ODE5MTYwMlowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEA016HNlvsQ7gxfHhIXX/7+CZHOVStKsJPNx/0hW341nFu
+69Z00U4Sl/cff8nJE07og5yDMkj1YEVi1fUvDFvyhiV2IM+672yEBi2DgVaoCm4d
+u/31Gb1itPmXp/oxLDHuPaentM/qOCxFaoDLN3KtRKQKOYgYGGh112+pZW1iqLnE
+FSQHZbe+1Byd76qqNTcYn0V2ieuJ6Mi2BrD1TXGClvdDOXFLcJ6ZP2yAfIQGjOTV
+DVowVn/Tw5aoNO3QrYdWK737de9rtYHq33WSKANmPhfTsk9nCvoA1S/BbX12LY19
+4rpmr0xRIVzeGBGnizaswEm+DCsNXdmXyXjRSkq6PwIDAQABo3YwdDAdBgNVHQ4E
+FgQU5k+HVDdmq2WVnHoL4fy3qygu8xUwHwYDVR0jBBgwFoAU5k+HVDdmq2WVnHoL
+4fy3qygu8xUwDwYDVR0TAQH/BAUwAwEB/zAhBgNVHREEGjAYhwR/AAABhxAAAAAA
+AAAAAAAAAAAAAAABMA0GCSqGSIb3DQEBCwUAA4IBAQBcUip2F8D87R29m+g+6LbA
+u1FaTIE4uPEMhqHDifcxkl/q1J7exSq8TMtwAQsNqg09scN//wpOCzYh1gHKmST5
++euP4X7VR/WPwkRqXZhUzVCQwJR5b46tJEnD7g+eNdGfCJJ1MhXDy/ghmC6BiMWg
+5LyCAaPxaTTz0F6xccCPD0DTrBJNkydHJ9gbabKHxHUw0OkSXNHkd2jhiUfzgjQ+
+BVhBRUY+f6sJ0uYmjrr5BWF2VvW/Fjng51ZScQVASv42R3VSER/grT466viHsRmT
++tPRn/CtBVO2P2ERJ/eWdJJFdW14yNbIrER56Xb59Z79WXI6vmIt9NJe79u+Ufq9
+-----END CERTIFICATE-----`)
+
+var testKey = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDTXoc2W+xDuDF8
+eEhdf/v4Jkc5VK0qwk83H/SFbfjWcW7r1nTRThKX9x9/yckTTuiDnIMySPVgRWLV
+9S8MW/KGJXYgz7rvbIQGLYOBVqgKbh27/fUZvWK0+Zen+jEsMe49p6e0z+o4LEVq
+gMs3cq1EpAo5iBgYaHXXb6llbWKoucQVJAdlt77UHJ3vqqo1NxifRXaJ64noyLYG
+sPVNcYKW90M5cUtwnpk/bIB8hAaM5NUNWjBWf9PDlqg07dCth1Yrvft172u1gerf
+dZIoA2Y+F9OyT2cK+gDVL8FtfXYtjX3iumavTFEhXN4YEaeLNqzASb4MKw1d2ZfJ
+eNFKSro/AgMBAAECggEAF2j4S8Z5j/SGEpWV2jkzFIRUzh45Qaucr2vMHr0T2thc
+YyVw8b+WYptdsz8LlKZgLTd39mlLN/rnW/AYYmOKpF3gy/iF6T+ZDcAbuQb6fJE+
+nNQfQdcOaCHesJ2OtajgDJcVhXqjo84PcCDMoRsD4r7SXRXcKVPkfVRiLBgl3a7l
+wuXNOmkxcZOslvtDWAtoWPd3u8usc4XhxGIYKNwuG08N5pcJCcbq7W+Lf8fUD/pF
+VukzqX5NLp/RoLyn6i+iKVEocuCMfmW5dczujbsYR/bqsCjFXJTvb710AJNEPwK9
+QJIO0YUhni6P7M5+aS/vYwwp1y0fpBv+yEHezocsiQKBgQD6ydelW4tcgGpCOdi8
+ab82J20KUpnebytmdYoq3PFnYxJRkyw9D0f5nlnGGm+0ZbAYGsl1v+RDoJ+opMOA
+MguDrtakvqKjRlURWWsVHrVyWRfslULKKw0KDcuXiu8R79WvFmOL+Xo/0q+g52KO
+JPFN5UCRXEhRoxaqFgfS4KtiuQKBgQDXwvtChPcUg5Z9Z34nTsQRyTMpq/38RPa5
+oRAO83o8Mn7ZtuI6WYKdSfozZa7SgP02p4dzVor2eOFMiSeF1RCysdTHInuE19iL
+UE/9uifYGbhEHXlUJ72P0o7Ll6Ko73Bg+i2TbckRs65Gk4u8ADU7ez5UMajB7bzr
+QitsZwxotwKBgQDuAOg68eoMW4J8X1GlXeYtirUc+s80HeTeU+ZQT2Z6a7dS2408
+VWhFKVahfy1L0sWP2rwel4IV/DYJYnR3EQeEbUUfDBxlP7YzxNyvKnmgj5T43Z6J
+Jto1FGqG4z+HkkkE5QaMLLMsJtKurWkG5WBsQIlKan3nnBNCT64VH0sHYQKBgG4E
+5K5UstDpEHG9thxBE8Wl/MrBAvACEnUxZcjZ6niLnxdRJCZwwiOGN2jB7tU0JOob
+nvv3I0Du/qNSRK7/qFYWS9OHB8kDb04Kk99jbzHIW6eQB/Abm5Oc4Gd8WNsfzQQG
+TfshPigioTknv1cMHBjKjUvNTqokmfK0eQP7v94dAoGACahWbGxB6zZbVwb2MQno
+mgp27KEpMF7ObnCLDRBcw6dNjnbk+Sr6epxsV+QtzTcgxhF+O306fLiYeqL1o+uE
+8oq9CIB6a4MN+huVhFnCLJ9bmpW/OSLPzgepXNZxWFP+UVEGONhn718fH0D4ytSc
+LZo5zivmnoir47JtzE9yTp4=
+-----END PRIVATE KEY-----`)

--- a/diam/sm/cer_test.go
+++ b/diam/sm/cer_test.go
@@ -5,6 +5,7 @@
 package sm
 
 import (
+	"crypto/tls"
 	"testing"
 	"time"
 
@@ -527,6 +528,57 @@ func TestHandleCER_InbandSecurity(t *testing.T) {
 	case resp := <-mc:
 		if !testResultCode(resp, diam.NoCommonSecurity) {
 			t.Fatalf("Unexpected result code.\n%s", resp)
+		}
+	case err := <-mux.ErrorReports():
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatal("No message received")
+	}
+}
+
+func TestHandleCER_InbandSecurity_WithTLSConfig(t *testing.T) {
+	// When the server has TLSConfig set, it should accept
+	// Inband-Security-Id=1 and attempt TLS upgrade after CEA.
+	// Since we can't easily do a real TLS upgrade in a unit test
+	// (the client would also need to upgrade), we verify the server
+	// accepts the CER and sends a success CEA instead of rejecting.
+	tlsSettings := *serverSettings
+	tlsSettings.TLSConfig = &tls.Config{} // non-nil signals TLS capability
+	sm := New(&tlsSettings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+	mc := make(chan *diam.Message, 1)
+	mux := diam.NewServeMux()
+	mux.HandleFunc("CEA", func(c diam.Conn, m *diam.Message) {
+		mc <- m
+	})
+	cli, err := diam.Dial(srv.Addr, mux, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+	m := diam.NewRequest(diam.CapabilitiesExchange, 0, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.InbandSecurityID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	_, err = m.WriteTo(cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case resp := <-mc:
+		// Should get a success CEA (not NO_COMMON_SECURITY)
+		if testResultCode(resp, diam.NoCommonSecurity) {
+			t.Fatal("Server rejected Inband-Security-Id=1 despite having TLSConfig")
+		}
+		if !testResultCode(resp, diam.Success) {
+			t.Fatalf("Expected success CEA.\n%s", resp)
 		}
 	case err := <-mux.ErrorReports():
 		t.Fatal(err)

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -5,6 +5,7 @@
 package sm
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/fiorix/go-diameter/v4/diam"
@@ -83,6 +84,11 @@ type Settings struct {
 	// peer has passed the handshake) before the state machine responds
 	// with DWA. Same semantics as OnCER.
 	OnDWR diam.HandlerFunc
+
+	// TLSConfig is optional. When set, the server can accept
+	// Inband-Security-Id=1 in CER and perform a TLS upgrade after
+	// sending CEA (RFC 6733 §6.2). Leave nil to reject in-band TLS.
+	TLSConfig *tls.Config
 }
 
 var (

--- a/diam/sm/smparser/cer.go
+++ b/diam/sm/smparser/cer.go
@@ -20,6 +20,13 @@ type CER struct {
 	AuthApplicationID           []*diam.AVP               `avp:"Auth-Application-Id"`
 	VendorSpecificApplicationID []*diam.AVP               `avp:"Vendor-Specific-Application-Id"`
 	appID                       []uint32                  // List of supported application IDs.
+	requestedSecurity           uint32                    // Negotiated Inband-Security-Id value.
+}
+
+// RequestedSecurity returns the Inband-Security-Id value from the CER
+// (0=NO_INBAND_SECURITY, 1=TLS). Valid after a successful Parse.
+func (cer *CER) RequestedSecurity() uint32 {
+	return cer.requestedSecurity
 }
 
 // Parse parses and validates the given message, and returns nil when
@@ -29,7 +36,7 @@ type CER struct {
 // error. If all mandatory AVPs are present but no common application
 // is found, then it returns the failedAVP (with the application that
 // we don't support in our dictionary) and an error. Another cause
-// for error is the presence of Inband Security, we don't support that.
+// for error is the presence of Inband Security when TLS is not active.
 func (cer *CER) Parse(m *diam.Message, localRole Role) (failedAVP *diam.AVP, err error) {
 	return cer.ParseWithSecurity(m, localRole, false)
 }
@@ -38,6 +45,11 @@ func (cer *CER) Parse(m *diam.Message, localRole Role) (failedAVP *diam.AVP, err
 // tlsActive is true, Inband-Security-Id=1 (TLS) is accepted because
 // the transport is already secured — per RFC 6733 §5.3.1 the peer is
 // simply declaring its TLS capability which is already satisfied.
+//
+// When tlsActive is false and tlsConfig is available on the server,
+// Inband-Security-Id=1 signals that a TLS upgrade should occur after
+// CEA is sent (RFC 6733 §6.2). The caller should check
+// RequestedSecurity() after a successful parse.
 func (cer *CER) ParseWithSecurity(m *diam.Message, localRole Role, tlsActive bool) (failedAVP *diam.AVP, err error) {
 	if err = m.Unmarshal(cer); err != nil {
 		return nil, err
@@ -46,7 +58,9 @@ func (cer *CER) ParseWithSecurity(m *diam.Message, localRole Role, tlsActive boo
 		return nil, err
 	}
 	if cer.InbandSecurityID != nil {
-		if v := cer.InbandSecurityID.Data.(datatype.Unsigned32); v != 0 && !tlsActive {
+		v := uint32(cer.InbandSecurityID.Data.(datatype.Unsigned32))
+		cer.requestedSecurity = v
+		if v != 0 && !tlsActive {
 			return nil, ErrNoCommonSecurity
 		}
 	}


### PR DESCRIPTION
Add support for upgrading a plain TCP connection to TLS after the CER/CEA exchange, as specified in RFC 6733 §6.2.

## Changes
- Add `TLSUpgrader` interface to `diam` package
- Add `StartTLS(*tls.Config) error` method to the server connection
- Add `TLSConfig *tls.Config` field to `sm.Settings`
- Update `handleCER`: when peer sends Inband-Security-Id=1 and server has TLSConfig, accept the CER, send success CEA, then upgrade to TLS
- Add `ParseWithSecurity()` and `RequestedSecurity()` to CER parser
- Add test verifying server accepts Inband-Security-Id=1 when TLSConfig is set

## RFC Reference
RFC 6733 §6.2:
> If TLS is to be used with a Diameter connection, the TLS handshake MUST begin immediately following the CER/CEA exchange for connections that are not pre-configured to use TLS.

## Backwards Compatibility
Without `TLSConfig` set in Settings, existing behavior is preserved (Inband-Security-Id=1 is rejected with NO_COMMON_SECURITY on plain connections).

All existing tests pass. The SCTP close test failure is pre-existing on upstream main.

Fixes #238
Related: #236, #239