### PR TITLE
fix: AVP decoding panic on dictionary/wire type mismatch

### DIFF
--- a/diam/avp.go
+++ b/diam/avp.go
@@ -102,15 +102,24 @@ func (a *AVP) DecodeFromBytes(data []byte, application uint32, dictionary *dict.
 	}
 	// Handle grouped AVPs directly to avoid an intermediate copy.
 	if dictAVP.Data.Type == datatype.GroupedType {
-		a.Data, err = DecodeGroupedFromBytes(payload, application, dictionary)
-		if err != nil {
-			return DecodeError(fmt.Errorf("%s(%d): Grouped{%v}", dictAVP.Name, dictAVP.Code, err))
+		g, groupErr := DecodeGroupedFromBytes(payload[:bodyLen], application, dictionary)
+		if groupErr != nil {
+			// Preserve raw bytes to prevent offset misalignment in the parent parse loop.
+			a.Data = datatype.Unknown(payload[:bodyLen])
+			return DecodeError(fmt.Errorf("%s(%d): Grouped{%v}", dictAVP.Name, dictAVP.Code, groupErr))
 		}
+		a.Data = g
 	} else {
-		a.Data, err = datatype.Decode(dictAVP.Data.Type, payload)
-		if err != nil {
-			return DecodeError(fmt.Errorf("%s(%d): %v", dictAVP.Name, dictAVP.Code, err))
+		decoded, decodeErr := datatype.Decode(dictAVP.Data.Type, payload[:bodyLen])
+		if decodeErr != nil || decoded.Len() != bodyLen {
+			// Preserve raw bytes to prevent offset misalignment in the parent parse loop.
+			if decodeErr == nil {
+				decodeErr = fmt.Errorf("size mismatch: %s expects %d bytes, wire has %d", dictAVP.Data.TypeName, decoded.Len(), bodyLen)
+			}
+			a.Data = datatype.Unknown(payload[:bodyLen])
+			return DecodeError(fmt.Errorf("%s(%d): %v", dictAVP.Name, dictAVP.Code, decodeErr))
 		}
+		a.Data = decoded
 	}
 	return nil
 }

--- a/diam/avp_test.go
+++ b/diam/avp_test.go
@@ -171,6 +171,125 @@ func TestDecodeAVPEmptyPayloadNoVendor(t *testing.T) {
 	_ = err
 }
 
+func TestDecodeAVPSizeMismatch(t *testing.T) {
+	// VendorId (code 266) is Unsigned32 in the dictionary (expects 4 bytes).
+	// This AVP has a 12-byte payload — a deliberate size mismatch.
+	raw := []byte{
+		0x00, 0x00, 0x01, 0x0a, // Code: 266 (VendorId)
+		0x40, 0x00, 0x00, 0x14, // Flags: M-bit, Length: 20 (8 header + 12 payload)
+		0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, // 12-byte payload
+	}
+	a, err := DecodeAVP(raw, 1, dict.Default)
+	if err == nil {
+		t.Fatal("Expected DecodeError for type size mismatch, got nil")
+	}
+	if _, ok := a.Data.(datatype.Unknown); !ok {
+		t.Fatalf("Expected Unknown data type for mismatched AVP, got %T", a.Data)
+	}
+	if got := a.Len(); got != 20 {
+		t.Fatalf("Expected Len()=20 (correct wire size), got %d", got)
+	}
+}
+
+func TestDecodeAVPGroupedWithNonGroupedBytes(t *testing.T) {
+	// Vendor-Specific-Application-Id (code 260) is Grouped in the dictionary.
+	// Payload bytes have a Length field (0xff=255) that exceeds available data,
+	// which is a fatal sub-AVP decode error.
+	raw := []byte{
+		0x00, 0x00, 0x01, 0x04, // Code: 260 (Vendor-Specific-Application-Id)
+		0x40, 0x00, 0x00, 0x10, // Flags: M-bit, Length: 16 (8 header + 8 payload)
+		0x01, 0x02, 0x03, 0x04, // garbage: sub-AVP code
+		0x40, 0x00, 0x00, 0xff, // garbage: sub-AVP Length=255 > 4 remaining bytes
+	}
+	a, err := DecodeAVP(raw, 0, dict.Default)
+	if err == nil {
+		t.Fatal("Expected DecodeError for grouped mismatch, got nil")
+	}
+	if _, ok := a.Data.(datatype.Unknown); !ok {
+		t.Fatalf("Expected Unknown data type for grouped mismatch AVP, got %T", a.Data)
+	}
+	if got := a.Len(); got != 16 {
+		t.Fatalf("Expected Len()=16 (correct wire size), got %d", got)
+	}
+}
+
+// testMismatchMessage is a raw CER message where the middle AVP (VendorId, code
+// 266) carries a 12-byte payload instead of the expected 4 bytes (Unsigned32).
+var testMismatchMessage = []byte{
+	// Diameter header (20 bytes)
+	0x01,             // Version
+	0x00, 0x00, 0x48, // Message Length: 72
+	0x80,             // Command Flags: Request
+	0x00, 0x01, 0x01, // Command Code: 257 (CER)
+	0x00, 0x00, 0x00, 0x00, // Application-ID: 0
+	0x00, 0x00, 0x00, 0x01, // Hop-by-Hop ID
+	0x00, 0x00, 0x00, 0x01, // End-to-End ID
+	// AVP 1: Origin-Host (code 264), "client" — 16 bytes
+	0x00, 0x00, 0x01, 0x08, // Code: 264
+	0x40, 0x00, 0x00, 0x0e, // Flags: M, Length: 14 (8+6)
+	0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x00, 0x00, // "client" + 2 padding
+	// AVP 2: VendorId (code 266, Unsigned32 in dict) with 12-byte payload — 20 bytes
+	0x00, 0x00, 0x01, 0x0a, // Code: 266
+	0x40, 0x00, 0x00, 0x14, // Flags: M, Length: 20 (8+12)
+	0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, // 12-byte payload (mismatch)
+	// AVP 3: Origin-Realm (code 296), "realm" — 16 bytes
+	0x00, 0x00, 0x01, 0x28, // Code: 296
+	0x40, 0x00, 0x00, 0x0d, // Flags: M, Length: 13 (8+5)
+	0x72, 0x65, 0x61, 0x6c, 0x6d, 0x00, 0x00, 0x00, // "realm" + 3 padding
+}
+
+func TestDecodeMessageWithSizeMismatchedAVP(t *testing.T) {
+	m, _ := ReadMessage(bytes.NewReader(testMismatchMessage), dict.Default)
+	if m == nil {
+		t.Fatal("Expected non-nil message even with decode error")
+	}
+	if len(m.AVP) != 3 {
+		t.Fatalf("Expected 3 AVPs, got %d", len(m.AVP))
+	}
+	if _, ok := m.AVP[1].Data.(datatype.Unknown); !ok {
+		t.Fatalf("Expected Unknown type for mismatched VendorId AVP, got %T", m.AVP[1].Data)
+	}
+	if got := m.AVP[1].Len(); got != 20 {
+		t.Fatalf("Expected mismatched AVP Len()=20, got %d", got)
+	}
+	if m.AVP[2].Code != avp.OriginRealm {
+		t.Fatalf("Expected Origin-Realm after mismatched AVP, got code %d", m.AVP[2].Code)
+	}
+	if got := string(m.AVP[2].Data.(datatype.DiameterIdentity)); got != "realm" {
+		t.Fatalf("Expected Origin-Realm=realm, got %q", got)
+	}
+}
+
+func TestDecodeGroupedWithTruncatedSubAVP(t *testing.T) {
+	// Auth-Application-Id sub-AVP (12 bytes) + 3 garbage bytes = 15 payload bytes.
+	// Outer AVP: code 260 (Vendor-Specific-Application-Id, Grouped), Length=23.
+	// One padding byte follows to align to 4 bytes.
+	raw := []byte{
+		0x00, 0x00, 0x01, 0x04, // Code: 260 (Vendor-Specific-Application-Id)
+		0x40, 0x00, 0x00, 0x17, // Flags: M, Length: 23 (8 header + 15 payload)
+		// Sub-AVP: Auth-Application-Id (code 258, Unsigned32=4) — 12 bytes
+		0x00, 0x00, 0x01, 0x02, // Code: 258
+		0x40, 0x00, 0x00, 0x0c, // Flags: M, Length: 12
+		0x00, 0x00, 0x00, 0x04, // Value: 4
+		// 3 trailing bytes — too few to form a sub-AVP header (need 8)
+		0x01, 0x02, 0x03,
+		0x00, // padding byte (not part of the AVP payload)
+	}
+	a, err := DecodeAVP(raw, 0, dict.Default)
+	if err == nil {
+		t.Fatal("Expected DecodeError for grouped with truncated sub-AVP, got nil")
+	}
+	if _, ok := a.Data.(datatype.Unknown); !ok {
+		t.Fatalf("Expected Unknown data type, got %T", a.Data)
+	}
+	// Len() must equal 24: 8 header + 15 payload + 1 padding (pad4(23)=24)
+	if got := a.Len(); got != 24 {
+		t.Fatalf("Expected Len()=24, got %d", got)
+	}
+}
+
 func BenchmarkDecodeAVP(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		DecodeAVP(testAVP[0], 1, dict.Default)

--- a/diam/group.go
+++ b/diam/group.go
@@ -36,6 +36,12 @@ func DecodeGroupedFromBytes(b []byte, application uint32, dictionary *dict.Parse
 		avp, err := DecodeAVP(b[n:], application, dictionary)
 		if err != nil {
 			errs = append(errs, err.Error())
+			if avp.Data == nil {
+				// Fatal decode error (e.g., truncated sub-AVP header): remaining
+				// bytes cannot form a valid sub-AVP. Break so the caller detects
+				// g.Len() != bodyLen and falls back to Unknown for the parent AVP.
+				break
+			}
 		}
 		g.AVP = append(g.AVP, avp)
 		n += avp.Len()

--- a/diam/group_test.go
+++ b/diam/group_test.go
@@ -53,6 +53,56 @@ func TestDecodeMessageWithGroupedAVP(t *testing.T) {
 	t.Logf("Message:\n%s", m)
 }
 
+func TestDecodeGroupedFromBytesHeaderTooShort(t *testing.T) {
+	b := []byte{0x01, 0x02, 0x03} // 3 bytes — cannot form an AVP header
+	g, err := DecodeGroupedFromBytes(b, 0, dict.Default)
+	if err == nil {
+		t.Fatal("Expected error for truncated header, got nil")
+	}
+	if len(g.AVP) != 0 {
+		t.Fatalf("Expected 0 sub-AVPs, got %d", len(g.AVP))
+	}
+}
+
+func TestDecodeGroupedFromBytesDataTooShort(t *testing.T) {
+	b := []byte{
+		0x01, 0x02, 0x03, 0x04, // Code
+		0x40,             // Flags: M-bit
+		0x00, 0x00, 0xff, // Length: 255 — far exceeds the 8 bytes available
+	}
+	g, err := DecodeGroupedFromBytes(b, 0, dict.Default)
+	if err == nil {
+		t.Fatal("Expected error for data-too-short sub-AVP, got nil")
+	}
+	if len(g.AVP) != 0 {
+		t.Fatalf("Expected 0 sub-AVPs (break before append), got %d", len(g.AVP))
+	}
+}
+
+func TestDecodeGroupedFromBytesValidThenTruncated(t *testing.T) {
+	b := []byte{
+		// Auth-Application-Id (code 258, Unsigned32=4) — 12 bytes, valid
+		0x00, 0x00, 0x01, 0x02, 0x40, 0x00, 0x00, 0x0c,
+		0x00, 0x00, 0x00, 0x04,
+		// 3 trailing bytes — too few to form a sub-AVP header (need 8)
+		0x01, 0x02, 0x03,
+	}
+	g, err := DecodeGroupedFromBytes(b, 0, dict.Default)
+	if err == nil {
+		t.Fatal("Expected error for truncated trailing bytes, got nil")
+	}
+	if len(g.AVP) != 1 {
+		t.Fatalf("Expected 1 decoded sub-AVP before the truncated remainder, got %d", len(g.AVP))
+	}
+	if g.AVP[0].Code != avp.AuthApplicationID {
+		t.Fatalf("Expected Auth-Application-Id (code %d), got %d", avp.AuthApplicationID, g.AVP[0].Code)
+	}
+	// g.Len() reflects only the successfully decoded sub-AVP.
+	if got := g.Len(); got != 12 {
+		t.Fatalf("Expected g.Len()=12, got %d", got)
+	}
+}
+
 func TestMakeGroupedAVP(t *testing.T) {
 	g := &GroupedAVP{
 		AVP: []*AVP{


### PR DESCRIPTION
Fix 2 bugs caused panics when a received Diameter message contained AVPs whose wire payload differed from the dictionary definition.

Add regression tests.

## bugs
- diam/avp.go: DecodeFromBytes()
    - when the decoded type's Len() does not match the wire payload length, fall back to datatype. Unknown so that AVP.Len() returns the correct wire size and the parent parse loop advances by the right offset.
- diam/group.go: DecodeGroupedFromBytes()
    - break out of the sub-AVP loop when a fatal decode error leaves avp.Data == nil, preventing a nil-interface panic in avp.Len().