### PR TITLE
sm: retain CEA capability AVPs (Vendor-Id, Product-Name, Supported-Vendor-Id) on smpeer.Metadata

### DIFF
--- a/diam/sm/smparser/cea.go
+++ b/diam/sm/smparser/cea.go
@@ -18,6 +18,9 @@ type CEA struct {
 	OriginHost                  datatype.DiameterIdentity `avp:"Origin-Host"`
 	OriginRealm                 datatype.DiameterIdentity `avp:"Origin-Realm"`
 	OriginStateID               uint32                    `avp:"Origin-State-Id"`
+	VendorID                    uint32                    `avp:"Vendor-Id"`           // Peer's Vendor-Id (RFC 6733 §5.3.2, mandatory).
+	ProductName                 string                    `avp:"Product-Name"`        // Peer's Product-Name (RFC 6733 §5.3.2, mandatory).
+	SupportedVendorID           []*diam.AVP               `avp:"Supported-Vendor-Id"` // Vendor-Ids the peer supports (RFC 6733 §5.3.2).
 	AcctApplicationID           []*diam.AVP               `avp:"Acct-Application-Id"`
 	AuthApplicationID           []*diam.AVP               `avp:"Auth-Application-Id"`
 	VendorSpecificApplicationID []*diam.AVP               `avp:"Vendor-Specific-Application-Id"`

--- a/diam/sm/smparser/cea_test.go
+++ b/diam/sm/smparser/cea_test.go
@@ -260,6 +260,45 @@ func TestCommonAppIdCEA(t *testing.T) {
 	}
 }
 
+// TestCEACapabilityAVPs verifies that the capability AVPs from RFC 6733 §5.3.2
+// (Vendor-Id, Product-Name, Supported-Vendor-Id) are parsed into the CEA struct.
+func TestCEACapabilityAVPs(t *testing.T) {
+	m := diam.NewMessage(diam.CapabilitiesExchange, 0, 0, 0, 0, nil)
+	m.NewAVP(avp.ResultCode, avp.Mbit, 0, datatype.Unsigned32(diam.Success))
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity("foobar"))
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity("test"))
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(10415))
+	m.NewAVP(avp.ProductName, 0, 0, datatype.UTF8String("go-diameter"))
+	m.NewAVP(avp.SupportedVendorID, avp.Mbit, 0, datatype.Unsigned32(10415))
+	m.NewAVP(avp.SupportedVendorID, avp.Mbit, 0, datatype.Unsigned32(13019))
+	m.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(4))
+
+	cea := new(CEA)
+	if err := cea.Parse(m, Client); err != nil {
+		t.Fatal(err)
+	}
+	if cea.VendorID != 10415 {
+		t.Fatalf("Unexpected Vendor-Id. Want 10415, have %d", cea.VendorID)
+	}
+	if cea.ProductName != "go-diameter" {
+		t.Fatalf("Unexpected Product-Name. Want %q, have %q", "go-diameter", cea.ProductName)
+	}
+	if len(cea.SupportedVendorID) != 2 {
+		t.Fatalf("Unexpected Supported-Vendor-Id count. Want 2, have %d", len(cea.SupportedVendorID))
+	}
+	want := []datatype.Unsigned32{10415, 13019}
+	for i, a := range cea.SupportedVendorID {
+		v, ok := a.Data.(datatype.Unsigned32)
+		if !ok {
+			t.Fatalf("Unexpected Supported-Vendor-Id type at %d. Want datatype.Unsigned32, have %T", i, a.Data)
+		}
+		if v != want[i] {
+			t.Fatalf("Unexpected Supported-Vendor-Id at %d. Want %d, have %d", i, want[i], v)
+		}
+	}
+}
+
 // TestCommonAppIdCEA tests that at least one CEA AppID exist in the default dictionary
 func TestCEAAutAndAcct(t *testing.T) {
 	m := diam.NewMessage(diam.CapabilitiesExchange, 0, 0, 0, 0, nil)

--- a/diam/sm/smpeer/metadata.go
+++ b/diam/sm/smpeer/metadata.go
@@ -21,6 +21,13 @@ type Metadata struct {
 	OriginHost   datatype.DiameterIdentity
 	OriginRealm  datatype.DiameterIdentity
 	Applications []uint32 // Acct or Auth IDs supported by the peer.
+
+	// Cer and Cea retain the full parsed handshake message so callers can
+	// read capability AVPs (e.g. Vendor-Id, Product-Name, Supported-Vendor-Id)
+	// that are not promoted to the fields above. Exactly one is set, matching
+	// which constructor was used: Cer for inbound peers, Cea for outbound.
+	Cer *smparser.CER
+	Cea *smparser.CEA
 }
 
 // FromCER creates a Metadata object from data in the CER.
@@ -29,6 +36,7 @@ func FromCER(cer *smparser.CER) *Metadata {
 		OriginHost:   cer.OriginHost,
 		OriginRealm:  cer.OriginRealm,
 		Applications: cer.Applications(),
+		Cer:          cer,
 	}
 }
 
@@ -38,6 +46,7 @@ func FromCEA(cea *smparser.CEA) *Metadata {
 		OriginHost:   cea.OriginHost,
 		OriginRealm:  cea.OriginRealm,
 		Applications: cea.Applications(),
+		Cea:          cea,
 	}
 }
 

--- a/diam/sm/smpeer/metadata.go
+++ b/diam/sm/smpeer/metadata.go
@@ -22,12 +22,12 @@ type Metadata struct {
 	OriginRealm  datatype.DiameterIdentity
 	Applications []uint32 // Acct or Auth IDs supported by the peer.
 
-	// Cer and Cea retain the full parsed handshake message so callers can
-	// read capability AVPs (e.g. Vendor-Id, Product-Name, Supported-Vendor-Id)
-	// that are not promoted to the fields above. Exactly one is set, matching
-	// which constructor was used: Cer for inbound peers, Cea for outbound.
-	Cer *smparser.CER
-	Cea *smparser.CEA
+	// CER and CEA retain the full parsed handshake message. Exactly one is
+	// set, matching which constructor was used: CER for inbound peers, CEA
+	// for outbound. CEA exposes the capability AVPs (Vendor-Id, Product-Name,
+	// Supported-Vendor-Id) that are not promoted to the fields above.
+	CER *smparser.CER
+	CEA *smparser.CEA
 }
 
 // FromCER creates a Metadata object from data in the CER.
@@ -36,7 +36,7 @@ func FromCER(cer *smparser.CER) *Metadata {
 		OriginHost:   cer.OriginHost,
 		OriginRealm:  cer.OriginRealm,
 		Applications: cer.Applications(),
-		Cer:          cer,
+		CER:          cer,
 	}
 }
 
@@ -46,7 +46,7 @@ func FromCEA(cea *smparser.CEA) *Metadata {
 		OriginHost:   cea.OriginHost,
 		OriginRealm:  cea.OriginRealm,
 		Applications: cea.Applications(),
-		Cea:          cea,
+		CEA:          cea,
 	}
 }
 

--- a/diam/sm/smpeer/metadata_test.go
+++ b/diam/sm/smpeer/metadata_test.go
@@ -26,6 +26,12 @@ func TestFromCER(t *testing.T) {
 		t.Fatalf("Unexpected OriginRealm. Want %q, have %q",
 			cer.OriginRealm, meta.OriginRealm)
 	}
+	if meta.Cer != cer {
+		t.Fatalf("Unexpected Cer. Want %p, have %p", cer, meta.Cer)
+	}
+	if meta.Cea != nil {
+		t.Fatalf("Unexpected Cea. Want nil, have %#v", meta.Cea)
+	}
 	ctx := NewContext(context.Background(), meta)
 	data, ok := FromContext(ctx)
 	if !ok {
@@ -49,6 +55,12 @@ func TestFromCEA(t *testing.T) {
 	if meta.OriginRealm != cer.OriginRealm {
 		t.Fatalf("Unexpected OriginRealm. Want %q, have %q",
 			cer.OriginRealm, meta.OriginRealm)
+	}
+	if meta.Cea != cer {
+		t.Fatalf("Unexpected Cea. Want %p, have %p", cer, meta.Cea)
+	}
+	if meta.Cer != nil {
+		t.Fatalf("Unexpected Cer. Want nil, have %#v", meta.Cer)
 	}
 	ctx := NewContext(context.Background(), meta)
 	data, ok := FromContext(ctx)

--- a/diam/sm/smpeer/metadata_test.go
+++ b/diam/sm/smpeer/metadata_test.go
@@ -26,11 +26,11 @@ func TestFromCER(t *testing.T) {
 		t.Fatalf("Unexpected OriginRealm. Want %q, have %q",
 			cer.OriginRealm, meta.OriginRealm)
 	}
-	if meta.Cer != cer {
-		t.Fatalf("Unexpected Cer. Want %p, have %p", cer, meta.Cer)
+	if meta.CER != cer {
+		t.Fatalf("Unexpected CER. Want %p, have %p", cer, meta.CER)
 	}
-	if meta.Cea != nil {
-		t.Fatalf("Unexpected Cea. Want nil, have %#v", meta.Cea)
+	if meta.CEA != nil {
+		t.Fatalf("Unexpected CEA. Want nil, have %#v", meta.CEA)
 	}
 	ctx := NewContext(context.Background(), meta)
 	data, ok := FromContext(ctx)
@@ -56,11 +56,11 @@ func TestFromCEA(t *testing.T) {
 		t.Fatalf("Unexpected OriginRealm. Want %q, have %q",
 			cer.OriginRealm, meta.OriginRealm)
 	}
-	if meta.Cea != cer {
-		t.Fatalf("Unexpected Cea. Want %p, have %p", cer, meta.Cea)
+	if meta.CEA != cer {
+		t.Fatalf("Unexpected CEA. Want %p, have %p", cer, meta.CEA)
 	}
-	if meta.Cer != nil {
-		t.Fatalf("Unexpected Cer. Want nil, have %#v", meta.Cer)
+	if meta.CER != nil {
+		t.Fatalf("Unexpected CER. Want nil, have %#v", meta.CER)
 	}
 	ctx := NewContext(context.Background(), meta)
 	data, ok := FromContext(ctx)


### PR DESCRIPTION
## Summary

The `smpeer` package already persists peer handshake `Metadata` on the connection context — `handleCER`/`handleCEA` call `c.SetContext(smpeer.NewContext(...))` so callers can read peer info after the handshake. Today it keeps only `Origin-Host`, `Origin-Realm` and the application list, and the parsed `CER`/`CEA` is then discarded.

This PR extends that existing mechanism so the remaining peer **capability AVPs** are reachable post-handshake:

- **`smparser.CEA`** gains:
  - `Vendor-Id` (`uint32`) — **mandatory** in the CEA grammar (RFC 6733 §5.3.2)
  - `Product-Name` (`string`) — **mandatory** (RFC 6733 §5.3.2)
  - `Supported-Vendor-Id` (`[]*diam.AVP`) — standard, optional, repeatable

  All parsed through the existing `avp:`-tag unmarshalling — no new parsing logic.
- **`smpeer.Metadata`** gains `Cer *smparser.CER` / `Cea *smparser.CEA` pointers to the parsed handshake message, populated by `FromCER`/`FromCEA`, so a consumer holding the connection can read any capability AVP the peer advertised.

## Motivation

`smpeer`'s stated purpose is *"extract information from a CER or CEA, and associate with a Context."* Persisting peer metadata on the connection is already the package's accepted design — this change simply stops it from dropping the (RFC-mandatory) `Vendor-Id`/`Product-Name` and the standard `Supported-Vendor-Id`, which a capabilities-introspection consumer otherwise cannot recover once the handshake completes.

## Compatibility

Purely additive:
- Existing `Metadata` fields and all current behaviour are unchanged.
- The new `Cer`/`Cea` pointers are `nil` unless the corresponding constructor is used.
- No signature changes; no on-wire change.

## Tests

- `smparser`: `TestCEACapabilityAVPs` parses a CEA carrying `Vendor-Id`, `Product-Name` and two `Supported-Vendor-Id` AVPs and asserts the new fields.
- `smpeer`: `TestFromCER`/`TestFromCEA` extended to assert the correct pointer is populated and the other is `nil`.
- `gofmt`/`go vet` clean; `go test -race -cover ./diam/sm/...` green (`smparser` 89.7%, `smpeer` 100%).