### PR TITLE
sm: add OnCEA/OnDWA server-side handshake hooks (follow-up to #233)

### DIFF
--- a/diam/sm/cer.go
+++ b/diam/sm/cer.go
@@ -104,6 +104,9 @@ func errorCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CER,
 	if sm.cfg.FirmwareRevision != 0 {
 		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
 	}
+	if sm.cfg.OnCEA != nil {
+		sm.cfg.OnCEA(c, a)
+	}
 	_, err = a.WriteTo(c)
 	if err != nil {
 		err = fmt.Errorf("Error CEA '%s' send failure: %v", errMessage, err)
@@ -163,6 +166,9 @@ func successCEA(sm *StateMachine, c diam.Conn, m *diam.Message, cer *smparser.CE
 	}
 	if sm.cfg.FirmwareRevision != 0 {
 		a.NewAVP(avp.FirmwareRevision, 0, 0, sm.cfg.FirmwareRevision)
+	}
+	if sm.cfg.OnCEA != nil {
+		sm.cfg.OnCEA(c, a)
 	}
 	_, err = a.WriteTo(c)
 	return err

--- a/diam/sm/dwr.go
+++ b/diam/sm/dwr.go
@@ -39,6 +39,9 @@ func handleDWR(sm *StateMachine) diam.HandlerFunc {
 			stateid := datatype.Unsigned32(sm.cfg.OriginStateID)
 			m.NewAVP(avp.OriginStateID, avp.Mbit, 0, stateid)
 		}
+		if sm.cfg.OnDWA != nil {
+			sm.cfg.OnDWA(c, a)
+		}
 		_, err = a.WriteTo(c)
 		if err != nil {
 			sm.Error(&diam.ErrorReport{

--- a/diam/sm/hooks_test.go
+++ b/diam/sm/hooks_test.go
@@ -117,3 +117,187 @@ func TestOnDWRHook(t *testing.T) {
 		t.Fatal("OnDWR hook did not fire")
 	}
 }
+
+// TestOnCEAHook verifies that Settings.OnCEA fires on the server immediately
+// before a (success) CEA is sent, with the fully-constructed answer message,
+// and that the default handshake still completes. Outbound counterpart of
+// TestOnCERHook.
+func TestOnCEAHook(t *testing.T) {
+	var onCEACalls int32
+	settings := *serverSettings
+	settings.OnCEA = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.CapabilitiesExchange {
+			t.Errorf("OnCEA invoked for non-CEA command %d", m.Header.CommandCode)
+		}
+		if m.Header.CommandFlags&diam.RequestFlag != 0 {
+			t.Errorf("OnCEA invoked with a request message, want an answer")
+		}
+		atomic.AddInt32(&onCEACalls, 1)
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	m := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := m.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-sm.HandshakeNotify():
+	case <-time.After(2 * time.Second):
+		t.Fatal("handshake did not complete after OnCEA hook")
+	}
+
+	if got := atomic.LoadInt32(&onCEACalls); got != 1 {
+		t.Fatalf("OnCEA calls = %d, want 1", got)
+	}
+}
+
+// TestOnCEAHookErrorCEA verifies that Settings.OnCEA also fires when the
+// server answers a CER with an error CEA (here: no common application),
+// covering the errorCEA call site as well as successCEA.
+func TestOnCEAHookErrorCEA(t *testing.T) {
+	var onCEACalls int32
+	onCEA := make(chan *diam.Message, 1)
+	settings := *serverSettings
+	settings.OnCEA = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.CapabilitiesExchange {
+			t.Errorf("OnCEA invoked for non-CEA command %d", m.Header.CommandCode)
+		}
+		if m.Header.CommandFlags&diam.RequestFlag != 0 {
+			t.Errorf("OnCEA invoked with a request message, want an answer")
+		}
+		if m.Header.CommandFlags&diam.ErrorFlag == 0 {
+			t.Errorf("OnCEA error-CEA message does not have the Error flag set")
+		}
+		atomic.AddInt32(&onCEACalls, 1)
+		select {
+		case onCEA <- m:
+		default:
+		}
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	// Request an application the server does not support, forcing errorCEA
+	// (DIAMETER_NO_COMMON_APPLICATION).
+	m := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	m.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	m.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	m.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	m.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	m.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	m.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(99999))
+	m.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := m.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case a := <-onCEA:
+		avpRC, err := a.FindAVP(avp.ResultCode, 0)
+		if err != nil {
+			t.Fatalf("OnCEA error answer has no Result-Code AVP: %v", err)
+		}
+		rc, ok := avpRC.Data.(datatype.Unsigned32)
+		if !ok {
+			t.Fatalf("OnCEA error answer Result-Code is not Unsigned32: %T", avpRC.Data)
+		}
+		if rc == diam.Success {
+			t.Fatalf("OnCEA error answer Result-Code = %d, want a non-success code", rc)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnCEA hook did not fire on errorCEA")
+	}
+
+	if got := atomic.LoadInt32(&onCEACalls); got != 1 {
+		t.Fatalf("OnCEA calls = %d, want 1", got)
+	}
+}
+
+// TestOnDWAHook verifies that Settings.OnDWA fires on the server immediately
+// before a DWA is sent in response to a peer DWR. Outbound counterpart of
+// TestOnDWRHook.
+func TestOnDWAHook(t *testing.T) {
+	onDWA := make(chan *diam.Message, 1)
+	settings := *serverSettings
+	settings.OnDWA = func(c diam.Conn, m *diam.Message) {
+		if m.Header.CommandCode != diam.DeviceWatchdog {
+			t.Errorf("OnDWA invoked for non-DWA command %d", m.Header.CommandCode)
+		}
+		if m.Header.CommandFlags&diam.RequestFlag != 0 {
+			t.Errorf("OnDWA invoked with a request message, want an answer")
+		}
+		select {
+		case onDWA <- m:
+		default:
+		}
+	}
+
+	sm := New(&settings)
+	srv := diamtest.NewServer(sm, dict.Default)
+	defer srv.Close()
+
+	cli, err := diam.Dial(srv.Addr, nil, dict.Default)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cli.Close()
+
+	cer := diam.NewRequest(diam.CapabilitiesExchange, 1001, dict.Default)
+	cer.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	cer.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	cer.NewAVP(avp.HostIPAddress, avp.Mbit, 0, localhostAddress)
+	cer.NewAVP(avp.VendorID, avp.Mbit, 0, clientSettings.VendorID)
+	cer.NewAVP(avp.ProductName, 0, 0, clientSettings.ProductName)
+	cer.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(1))
+	cer.NewAVP(avp.AcctApplicationID, avp.Mbit, 0, datatype.Unsigned32(1001))
+	cer.NewAVP(avp.FirmwareRevision, 0, 0, clientSettings.FirmwareRevision)
+	if _, err := cer.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-sm.HandshakeNotify():
+	case <-time.After(2 * time.Second):
+		t.Fatal("handshake did not complete")
+	}
+
+	dwr := diam.NewRequest(diam.DeviceWatchdog, 0, dict.Default)
+	dwr.NewAVP(avp.OriginHost, avp.Mbit, 0, clientSettings.OriginHost)
+	dwr.NewAVP(avp.OriginRealm, avp.Mbit, 0, clientSettings.OriginRealm)
+	if _, err := dwr.WriteTo(cli); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-onDWA:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnDWA hook did not fire")
+	}
+}

--- a/diam/sm/sm.go
+++ b/diam/sm/sm.go
@@ -79,10 +79,18 @@ type Settings struct {
 	// handshake.
 	OnCER diam.HandlerFunc
 
+	// OnCEA, if non-nil, is invoked immediately before a CEA is sent (both
+	// the success CEA and the error CEA). Useful for logging or metrics.
+	OnCEA diam.HandlerFunc
+
 	// OnDWR, if non-nil, is invoked when a DWR is received (after the
 	// peer has passed the handshake) before the state machine responds
 	// with DWA. Same semantics as OnCER.
 	OnDWR diam.HandlerFunc
+
+	// OnDWA, if non-nil, is invoked immediately before a DWA is sent in
+	// response to a peer DWR. Useful for logging or metrics.
+	OnDWA diam.HandlerFunc
 }
 
 var (


### PR DESCRIPTION
## Summary

PR #233 added `Settings.OnCER` and `Settings.OnDWR` pre-hooks for server-side **inbound** CER and DWR. This adds the symmetric **outbound** pair:

- **`OnCEA`** — invoked immediately before a CEA is sent, on the fully-constructed answer. Fires for both the success CEA (`successCEA`) and the error CEA (`errorCEA`).
- **`OnDWA`** — invoked immediately before a DWA is sent in response to a peer DWR (`handleDWR`).

Both are nil-guarded `diam.HandlerFunc` fields on `Settings`. Default behaviour is unchanged when nil — pure additive, no signature changes, no behaviour change for existing users.

## Why a call-site hook (not `chainPreHook`)

CEA and DWA are **built and sent by the state machine internally**, and `sm.HandleFunc`/`HandleIdx` explicitly refuse `CER`/`CEA`/`DWR` handler registration to protect the handshake. So the server's outbound handshake answers have no user interception point — exactly the situation #233 solved for inbound CER/DWR. `chainPreHook` only applies to *received* messages dispatched on the mux; for an answer the SM constructs and writes itself, a nil-guarded call-site insert before `a.WriteTo(c)` is the minimal mechanism.

## Changes

| File | Change |
|---|---|
| `diam/sm/sm.go` | `OnCEA`/`OnDWA` fields on `Settings` (paired with `OnCER`/`OnDWR`), doc comments in the same style |
| `diam/sm/cer.go` | nil-guarded `OnCEA` call before send in `successCEA` **and** `errorCEA` |
| `diam/sm/dwr.go` | nil-guarded `OnDWA` call before send in `handleDWR` |
| `diam/sm/hooks_test.go` | `TestOnCEAHook`, `TestOnCEAHookErrorCEA`, `TestOnDWAHook` — mirroring the `TestOnCERHook`/`TestOnDWRHook` template |

## Testing

- `go test -race ./diam/sm/` passes; the three new tests cover the success-CEA, error-CEA (forced via an unsupported `Acct-Application-Id` → `DIAMETER_NO_COMMON_APPLICATION`), and DWA paths.
- `go vet ./...` clean; `gofmt` clean.
- Default-behaviour-unchanged is covered by the existing handshake tests passing unmodified.