### PR TITLE
diam: fix nil-pointer panic decoding malformed grouped AVPs

### DIFF
--- a/diam/group.go
+++ b/diam/group.go
@@ -35,7 +35,10 @@ func DecodeGroupedFromBytes(b []byte, application uint32, dictionary *dict.Parse
 	for n := 0; n < len(b); {
 		avp, err := DecodeAVP(b[n:], application, dictionary)
 		if err != nil {
+			// Stop: framing is now untrustworthy and avp.Data may be nil, so
+			// advancing by avp.Len() would panic.
 			errs = append(errs, err.Error())
+			break
 		}
 		g.AVP = append(g.AVP, avp)
 		n += avp.Len()

--- a/diam/group_test.go
+++ b/diam/group_test.go
@@ -71,3 +71,18 @@ func TestMakeGroupedAVP(t *testing.T) {
 	}
 	t.Logf("Message:\n%s", a)
 }
+
+// TestDecodeGroupedFromBytesMalformed ensures a sub-AVP whose header is too
+// short (leaving its Data nil) yields an error instead of a nil-pointer panic.
+func TestDecodeGroupedFromBytesMalformed(t *testing.T) {
+	// One AVP header declaring a length of 4, which is shorter than the 8-byte
+	// minimum, so DecodeAVP returns an error with a nil Data.
+	b := []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04}
+	g, err := DecodeGroupedFromBytes(b, 0, dict.Default)
+	if err == nil {
+		t.Fatal("expected an error for the malformed grouped AVP")
+	}
+	if g == nil {
+		t.Fatal("expected a non-nil partial group")
+	}
+}

--- a/diam/message.go
+++ b/diam/message.go
@@ -166,6 +166,11 @@ func (m *Message) decodeAVPs(b []byte) error {
 				return err
 			}
 		}
+		if a.Data == nil {
+			// Stop: without Data we cannot compute a.Len() to advance, and the
+			// framing is corrupt anyway.
+			break
+		}
 		m.AVP = append(m.AVP, a)
 		n += a.Len()
 	}


### PR DESCRIPTION
DecodeGroupedFromBytes and the top-level decodeAVPs loop advanced the read offset by avp.Len() even when DecodeAVP returned an error.
On an error, the AVP's Data can be nil, and AVP.Len() dereferences it, so a grouped AVP whose sub-AVP fails to decode panics instead of returning an error.

Both loops now stop on the first decode error, returning the partial result plus the error.
