### PR TITLE
diam: don't close the connection on an unregistered application/command

### DIFF
--- a/diam/message.go
+++ b/diam/message.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net"
 	"strings"
@@ -23,6 +24,19 @@ import (
 
 // MessageBufferLength is the default buffer length for Diameter messages.
 var MessageBufferLength = 1 << 10
+
+// unknownCommand is used when the dictionary has no application/command
+// entry for a received message (e.g. an application whose dictionary isn't
+// loaded at all). Its permissive rule set lets decodeAVPs run generically
+// instead of aborting -- AVP-level lookups already degrade to
+// datatype.Unknown for codes the dictionary doesn't recognize
+// (dict.FindAVPByCode), so a message like this still decodes instead of
+// erroring out, even though its AVPs come back untyped.
+var unknownCommand = &dict.Command{
+	Name:    "Unknown",
+	Request: dict.CommandRule{Rule: make([]*dict.Rule, 32)},
+	Answer:  dict.CommandRule{Rule: make([]*dict.Rule, 32)},
+}
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -113,7 +127,9 @@ func (m *Message) readHeader(r io.Reader, buf *bytes.Buffer) (cmd *dict.Command,
 		m.Header.CommandCode,
 	)
 	if err != nil {
-		return nil, stream, err
+		log.Printf("diam: no dictionary command for app %d code %d, decoding generically: %v",
+			m.Header.ApplicationID, m.Header.CommandCode, err)
+		cmd = unknownCommand
 	}
 	return cmd, stream, nil
 }

--- a/diam/message_test.go
+++ b/diam/message_test.go
@@ -152,6 +152,59 @@ func TestReadMessageWithVendorID(t *testing.T) {
 	t.Logf("Message:\n%s", msg)
 }
 
+// TestReadMessageUnregisteredApplication covers a message whose
+// Application-Id has no dictionary entry at all (e.g. 3GPP Cx/Dx,
+// 16777216, isn't part of dict.Default). Before this fix, readHeader's
+// FindCommand lookup failed outright for ANY message on such an
+// application -- even a well-formed one carrying only ordinary AVPs -- and
+// ReadMessage returned an error. Since conn.serve() closes the whole
+// connection on any ReadMessage error, a single message on an unregistered
+// application used to take down the entire peer connection, not just that
+// one message.
+//
+// FindAVPByCode doesn't chain to the base application (id 0) for an
+// unregistered app, so even well-known AVPs like Result-Code decode as
+// datatype.Unknown here rather than their typed dictionary value -- decoding
+// no longer errors out, which is what this fix addresses, but recovering
+// typed values for base AVPs on unregistered applications is a separate
+// concern this change doesn't attempt to solve.
+func TestReadMessageUnregisteredApplication(t *testing.T) {
+	const unregisteredApp = 16777216 // 3GPP Cx/Dx, not in dict.Default
+	const someCommand = 303          // Multimedia-Auth-Request/Answer
+
+	m := NewMessage(someCommand, 0, unregisteredApp, 1, 1, dict.Default)
+	if _, err := m.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("cx;1;1")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.NewAVP(avp.ResultCode, avp.Mbit, 0, datatype.Unsigned32(2001)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity("hss")); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := m.WriteTo(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadMessage(&buf, dict.Default)
+	if err != nil {
+		t.Fatalf("ReadMessage should decode generically for an unregistered application, got error: %v", err)
+	}
+	if len(got.AVP) != 3 {
+		t.Fatalf("got %d AVPs, want 3", len(got.AVP))
+	}
+	rc, err := got.FindAVP(avp.ResultCode, 0)
+	if err != nil {
+		t.Fatalf("Result-Code AVP not found: %v", err)
+	}
+	want := datatype.Unknown{0x00, 0x00, 0x07, 0xd1} // 2001, big-endian
+	if got, ok := rc.Data.(datatype.Unknown); !ok || !bytes.Equal(got, want) {
+		t.Fatalf("Result-Code raw bytes = %#v, want %#v", rc.Data, want)
+	}
+}
+
 func TestNewMessage(t *testing.T) {
 	want, _ := ReadMessage(bytes.NewReader(testMessage), dict.Default)
 	m := NewMessage(CapabilitiesExchange, RequestFlag, 0, 0xa8cc407d, 0xa8c1b2b4, dict.Default)


### PR DESCRIPTION
## Summary

- `readHeader`'s `FindCommand` lookup hard-fails for any `(application, command)` pair the loaded dictionary doesn't know about — e.g. an application whose XML dictionary isn't part of `dict.Default` at all, such as 3GPP Cx/Dx (16777216). `ReadMessage` then returns an error for an otherwise well-formed message.
- `conn.serve()` responds to *any* `ReadMessage` error by closing the whole connection (`c.rwc.Close(); break`) — so one message on an unregistered application takes down the entire peer link, including every other request in flight on it.
- Fix: fall back to a permissive `Command` instead of erroring, so `decodeAVPs` still runs. AVP-level lookups already degrade to `datatype.Unknown` for codes the dictionary doesn't recognize (`dict.FindAVPByCode`), so the message decodes without error — its AVPs just come back untyped when the application itself is unregistered.

Found this while load-testing a Diameter HSS: a client advertising both S6a/SWx (which `dict.Default` ships) and Cx/Dx (which it doesn't) in its CER would have its whole connection killed by a single Cx answer, even though the peer sent a perfectly valid message.

## Test plan

- [x] Added `TestReadMessageUnregisteredApplication`, reproducing the crash with a well-formed message on an unregistered application-id, asserting `ReadMessage` no longer errors.
- [x] `go test ./diam/...` passes (existing suite untouched).
- [x] `go vet ./diam/...` clean.
- [x] Verified against a real Diameter peer via [xk6-diameter](https://github.com/lwlee2608/xk6-diameter) load-testing a Cx MAR/MAA exchange against a live HSS — went from every request timing out (connection silently torn down) to 100% success.